### PR TITLE
Surface book 2 15 inch does not need Y axis inverted

### DIFF
--- a/config/surface-book2-15.conf
+++ b/config/surface-book2-15.conf
@@ -5,7 +5,7 @@ Product = 0x0020
 [Config]
 # Needs to be verified by a device owner
 InvertX = false
-InvertY = true
+InvertY = false
 
 Width = 3171
 Height = 2114


### PR DESCRIPTION
Exciting to see this working! My Surface book 2 15" does not need to have y-axis inverted