### PR TITLE
Improve palm detection

### DIFF
--- a/processing/contact.go
+++ b/processing/contact.go
@@ -20,17 +20,30 @@ func Hypot(x float32, y float32) float32 {
 	return float32(math.Hypot(float64(x), float64(y)))
 }
 
+type Cluster struct {
+	X    int
+	Y    int
+	XX   int
+	YY   int
+	XY   int
+	W    int
+	MaxV int
+}
+
 type Contact struct {
-	X      int
-	Y      int
-	XX     int
-	YY     int
-	XY     int
-	W      int
+	X      float32 // center
+	Y      float32
+	Ev1    float32 // covariance matrix eigenvalues
+	Ev2    float32
+	qx1    float32 // covariance matrix eigenvectors
+	qy1    float32
+	qx2    float32
+	qy2    float32
+	MaxV   int
 	isPalm bool
 }
 
-func (hm *Heatmap) GetCluster(x int, y int, res *Contact) {
+func (hm *Heatmap) GetCluster(x int, y int, res *Cluster) {
 	v := hm.Value(x, y)
 
 	if v < TOUCH_THRESHOLD {
@@ -61,6 +74,8 @@ func (hm *Heatmap) Contacts(contacts []Contact) int {
 		hm.Visited[i] = false
 	}
 
+	var cluster Cluster
+
 	for x := 0; x < hm.Width; x++ {
 		for y := 0; y < hm.Height; y++ {
 			if hm.Value(x, y) < TOUCH_THRESHOLD {
@@ -71,12 +86,12 @@ func (hm *Heatmap) Contacts(contacts []Contact) int {
 				continue
 			}
 
-			contacts[c] = Contact{}
+			cluster = Cluster{}
 
-			hm.GetCluster(x, y, &contacts[c])
-			vx, vy, _ := contacts[c].Cov()
+			hm.GetCluster(x, y, &cluster)
+			contacts[c].GetFromCluster(cluster)
 			// ignore 0 variance contacts
-			if vx > 0 && vy > 0 {
+			if contacts[c].Ev2 > 0 {
 				c += 1
 			}
 
@@ -89,16 +104,19 @@ func (hm *Heatmap) Contacts(contacts []Contact) int {
 	return c
 }
 
-func (c *Contact) Add(x int, y int, w int) {
+func (c *Cluster) Add(x int, y int, w int) {
 	c.X += w * x
 	c.Y += w * y
 	c.XX += w * x * x
 	c.YY += w * y * y
 	c.XY += w * x * y
 	c.W += w
+	if c.MaxV < w {
+		c.MaxV = w
+	}
 }
 
-func (c *Contact) Mean() (float32, float32) {
+func (c *Cluster) Mean() (float32, float32) {
 	fX := float32(c.X)
 	fY := float32(c.Y)
 	fW := float32(c.W)
@@ -106,7 +124,7 @@ func (c *Contact) Mean() (float32, float32) {
 	return fX / fW, fY / fW
 }
 
-func (c *Contact) Cov() (float32, float32, float32) {
+func (c *Cluster) Cov() (float32, float32, float32) {
 	fX := float32(c.X)
 	fY := float32(c.Y)
 	fXX := float32(c.XX)
@@ -121,7 +139,7 @@ func (c *Contact) Cov() (float32, float32, float32) {
 	return r1, r2, r3
 }
 
-func (c *Contact) Eigenvalues() (float32, float32) {
+func (c *Cluster) Eigenvalues() (float32, float32) {
 	vx, vy, cv := c.Cov()
 	sqrtd := Sqrt(((vx-vy)*(vx-vy) + 4*cv*cv))
 
@@ -131,48 +149,55 @@ func (c *Contact) Eigenvalues() (float32, float32) {
 	return r1, r2
 }
 
+func (c *Contact) GetFromCluster(cluster Cluster) {
+	c.X, c.Y = cluster.Mean()
+	vx, vy, cv := cluster.Cov()
+
+	sqrtd := Sqrt(((vx-vy)*(vx-vy) + 4*cv*cv))
+
+	c.Ev1 = (vx + vy + sqrtd) / 2
+	c.Ev2 = (vx + vy - sqrtd) / 2
+
+	c.qx1 = vx + cv - c.Ev2
+	c.qy1 = vy + cv - c.Ev2
+	d1 := Hypot(c.qx1, c.qy1)
+	c.qx1 /= d1
+	c.qy1 /= d1
+
+	c.qx2 = vx + cv - c.Ev1
+	c.qy2 = vy + cv - c.Ev1
+	d2 := Hypot(c.qx2, c.qy2)
+	c.qx2 /= d2
+	c.qy2 /= d2
+
+	c.MaxV = cluster.MaxV
+
+	c.isPalm = false
+}
+
 func (c *Contact) PCA(x float32, y float32) (float32, float32) {
-	vx, vy, cv := c.Cov()
-
-	l1, l2 := c.Eigenvalues()
-
-	qx1 := vx + cv - l2
-	qy1 := vy + cv - l2
-	d1 := Hypot(qx1, qy1)
-	qx1 /= d1
-	qy1 /= d1
-
-	qx2 := vx + cv - l1
-	qy2 := vy + cv - l1
-	d2 := Hypot(qx2, qy2)
-	qx2 /= d2
-	qy2 /= d2
-
-	return qx1*x + qx2*y, qy1*x + qy2*y
+	return c.qx1*x + c.qx2*y, c.qy1*x + c.qy2*y
 }
 
 func (c *Contact) Near(other Contact) bool {
-	x1, y1 := c.Mean()
-	x2, y2 := other.Mean()
-	dx, dy := other.PCA(x1-x2, y1-y2)
+	dx, dy := other.PCA(c.X-other.X, c.Y-other.Y)
 	dx, dy = Abs(dx), Abs(dy)
 
-	vx, vy := other.Eigenvalues()
-	dx /= 3.2*Sqrt(vx) + 5
-	dy /= 3.2*Sqrt(vy) + 5
+	dx /= 3.2*Sqrt(other.Ev1) + 8
+	dy /= 3.2*Sqrt(other.Ev2) + 8
 
 	return dx*dx+dy*dy <= 1
 }
 
 func GetPalms(contacts []Contact, count int) {
 	for i := 0; i < count; i++ {
-		vx, vy := contacts[i].Eigenvalues()
+		vx, vy, maxV := contacts[i].Ev1, contacts[i].Ev2, contacts[i].MaxV
 
-		if vx < 1.0 && vy < 1.0 { // Regular touch
+		if vx < 0.6 || vx < 1.0 && maxV > 80 { // Regular touch
 			continue
 		}
 
-		if vx < 3.0 && vx/vy > 1.8 && vx/vy < 3.4 { // Thumb
+		if (vx < 1.25 || vx < 3.5 && maxV > 90) && vx/vy > 1.8 { // Thumb
 			continue
 		}
 

--- a/processing/contact.go
+++ b/processing/contact.go
@@ -1,24 +1,8 @@
 package processing
 
-import (
-	"math"
-)
-
 const (
 	TOUCH_THRESHOLD = byte(10)
 )
-
-func Abs(x float32) float32 {
-	return float32(math.Abs(float64(x)))
-}
-
-func Sqrt(x float32) float32 {
-	return float32(math.Sqrt(float64(x)))
-}
-
-func Hypot(x float32, y float32) float32 {
-	return float32(math.Hypot(float64(x), float64(y)))
-}
 
 type Cluster struct {
 	X    int
@@ -40,7 +24,7 @@ type Contact struct {
 	qx2    float32
 	qy2    float32
 	MaxV   int
-	isPalm bool
+	IsPalm bool
 }
 
 func (hm *Heatmap) GetCluster(x int, y int, res *Cluster) {
@@ -74,8 +58,6 @@ func (hm *Heatmap) Contacts(contacts []Contact) int {
 		hm.Visited[i] = false
 	}
 
-	var cluster Cluster
-
 	for x := 0; x < hm.Width; x++ {
 		for y := 0; y < hm.Height; y++ {
 			if hm.Value(x, y) < TOUCH_THRESHOLD {
@@ -86,10 +68,10 @@ func (hm *Heatmap) Contacts(contacts []Contact) int {
 				continue
 			}
 
-			cluster = Cluster{}
-
+			cluster := Cluster{}
 			hm.GetCluster(x, y, &cluster)
 			contacts[c].GetFromCluster(cluster)
+
 			// ignore 0 variance contacts
 			if contacts[c].Ev2 > 0 {
 				c += 1
@@ -172,7 +154,7 @@ func (c *Contact) GetFromCluster(cluster Cluster) {
 
 	c.MaxV = cluster.MaxV
 
-	c.isPalm = false
+	c.IsPalm = false
 }
 
 func (c *Contact) PCA(x float32, y float32) (float32, float32) {
@@ -201,15 +183,15 @@ func GetPalms(contacts []Contact, count int) {
 			continue
 		}
 
-		contacts[i].isPalm = true
+		contacts[i].IsPalm = true
 
 		for j := 0; j < count; j++ {
-			if j == i || contacts[j].isPalm {
+			if j == i || contacts[j].IsPalm {
 				continue
 			}
 
 			if contacts[j].Near(contacts[i]) {
-				contacts[j].isPalm = true
+				contacts[j].IsPalm = true
 			}
 		}
 	}

--- a/processing/contact.go
+++ b/processing/contact.go
@@ -74,7 +74,11 @@ func (hm *Heatmap) Contacts(contacts []Contact) int {
 			contacts[c] = Contact{}
 
 			hm.GetCluster(x, y, &contacts[c])
-			c += 1
+			vx, vy, _ := contacts[c].Cov()
+			// ignore 0 variance contacts
+			if vx > 0 && vy > 0 {
+				c += 1
+			}
 
 			if c == len(contacts) {
 				return c

--- a/processing/contact.go
+++ b/processing/contact.go
@@ -5,7 +5,7 @@ import (
 )
 
 const (
-	TOUCH_THRESHOLD = byte(30)
+	TOUCH_THRESHOLD = byte(10)
 )
 
 func Abs(x float32) float32 {
@@ -164,7 +164,11 @@ func GetPalms(contacts []Contact, count int) {
 	for i := 0; i < count; i++ {
 		vx, vy := contacts[i].Eigenvalues()
 
-		if vx < 1.5 && vy < 1.5 {
+		if vx < 1.0 && vy < 1.0 { // Regular touch
+			continue
+		}
+
+		if vx < 3.0 && vx/vy > 1.8 && vx/vy < 3.4 { // Thumb
 			continue
 		}
 

--- a/processing/finger.go
+++ b/processing/finger.go
@@ -101,7 +101,7 @@ func (tp *TouchProcessor) FindDuplicates(count int, itr int) bool {
 		dev2 := tp.inputs[i].Ev2 - last.Ev2
 
 		tp.inputs[i].Index = last.Index
-		tp.inputs[i].IsPalm = contact.isPalm || last.IsPalm
+		tp.inputs[i].IsPalm = contact.IsPalm || last.IsPalm
 		tp.inputs[i].IsStable = dev1 < STABILITY_THRESHOLD && dev2 < STABILITY_THRESHOLD
 
 		duplicates--
@@ -151,7 +151,7 @@ func (tp *TouchProcessor) TrackFingers(count int) {
 		dev2 := tp.inputs[i].Ev2 - last.Ev2
 
 		tp.inputs[i].Index = last.Index
-		tp.inputs[i].IsPalm = contact.isPalm || last.IsPalm
+		tp.inputs[i].IsPalm = contact.IsPalm || last.IsPalm
 		tp.inputs[i].IsStable = dev1 < STABILITY_THRESHOLD && dev2 < STABILITY_THRESHOLD
 	}
 

--- a/processing/finger.go
+++ b/processing/finger.go
@@ -97,10 +97,12 @@ func (tp *TouchProcessor) FindDuplicates(count int, itr int) bool {
 		last := tp.last[tp.indices[i][itr]]
 		contact := tp.inputs[i].contact
 
+		dev1 := tp.inputs[i].Ev1 - last.Ev1
+		dev2 := tp.inputs[i].Ev2 - last.Ev2
+
 		tp.inputs[i].Index = last.Index
 		tp.inputs[i].IsPalm = contact.isPalm || last.IsPalm
-		tp.inputs[i].IsStable = Abs(last.Ev1-tp.inputs[i].Ev1) < STABILITY_THRESHOLD ||
-			Abs(last.Ev2-tp.inputs[i].Ev2) < STABILITY_THRESHOLD
+		tp.inputs[i].IsStable = dev1 < STABILITY_THRESHOLD && dev2 < STABILITY_THRESHOLD
 
 		duplicates--
 
@@ -145,8 +147,8 @@ func (tp *TouchProcessor) TrackFingers(count int) {
 	for i := 0; i < count; i++ {
 		last := tp.last[tp.indices[i][0]]
 		contact := tp.inputs[i].contact
-		dev1 := Abs(last.Ev1 - tp.inputs[i].Ev1)
-		dev2 := Abs(last.Ev2 - tp.inputs[i].Ev2)
+		dev1 := tp.inputs[i].Ev1 - last.Ev1
+		dev2 := tp.inputs[i].Ev2 - last.Ev2
 
 		tp.inputs[i].Index = last.Index
 		tp.inputs[i].IsPalm = contact.isPalm || last.IsPalm

--- a/processing/finger.go
+++ b/processing/finger.go
@@ -1,5 +1,7 @@
 package processing
 
+const STABILITY_THRESHOLD = 0.1
+
 /*
  * Go doesn't really provide a way to sort a list using a custom
  * comparison, without also allocating a new list. The solution is
@@ -97,6 +99,8 @@ func (tp *TouchProcessor) FindDuplicates(count int, itr int) bool {
 
 		tp.inputs[i].Index = last.Index
 		tp.inputs[i].IsPalm = contact.isPalm || last.IsPalm
+		tp.inputs[i].IsStable = Abs(last.Ev1-tp.inputs[i].Ev1) < STABILITY_THRESHOLD ||
+			Abs(last.Ev2-tp.inputs[i].Ev2) < STABILITY_THRESHOLD
 
 		duplicates--
 
@@ -141,9 +145,12 @@ func (tp *TouchProcessor) TrackFingers(count int) {
 	for i := 0; i < count; i++ {
 		last := tp.last[tp.indices[i][0]]
 		contact := tp.inputs[i].contact
+		dev1 := Abs(last.Ev1 - tp.inputs[i].Ev1)
+		dev2 := Abs(last.Ev2 - tp.inputs[i].Ev2)
 
 		tp.inputs[i].Index = last.Index
 		tp.inputs[i].IsPalm = contact.isPalm || last.IsPalm
+		tp.inputs[i].IsStable = dev1 < STABILITY_THRESHOLD && dev2 < STABILITY_THRESHOLD
 	}
 
 	/*

--- a/processing/touch.go
+++ b/processing/touch.go
@@ -116,7 +116,7 @@ func (tp *TouchProcessor) Inputs(hm *Heatmap) []TouchInput {
 			Ev2:      tp.contacts[i].Ev2,
 			Index:    i,
 			IsStable: false,
-			IsPalm:   tp.contacts[i].isPalm,
+			IsPalm:   tp.contacts[i].IsPalm,
 			contact:  &tp.contacts[i],
 		}
 	}

--- a/processing/touch.go
+++ b/processing/touch.go
@@ -110,24 +110,26 @@ func (tp *TouchProcessor) Inputs(hm *Heatmap) []TouchInput {
 		}
 
 		tp.inputs[i] = TouchInput{
-			X:       int(x * 9600),
-			Y:       int(y * 7200),
-			Ev1:     tp.contacts[i].Ev1,
-			Ev2:     tp.contacts[i].Ev2,
-			Index:   i,
-			IsPalm:  tp.contacts[i].isPalm,
-			contact: &tp.contacts[i],
+			X:        int(x * 9600),
+			Y:        int(y * 7200),
+			Ev1:      tp.contacts[i].Ev1,
+			Ev2:      tp.contacts[i].Ev2,
+			Index:    i,
+			IsStable: false,
+			IsPalm:   tp.contacts[i].isPalm,
+			contact:  &tp.contacts[i],
 		}
 	}
 
 	for i := count; i < tp.MaxTouchPoints; i++ {
 		tp.inputs[i] = TouchInput{
-			X:       0,
-			Y:       0,
-			Ev1:     0,
-			Ev2:     0,
-			Index:   -1,
-			contact: &tp.contacts[i],
+			X:        0,
+			Y:        0,
+			Ev1:      0,
+			Ev2:      0,
+			Index:    -1,
+			IsStable: false,
+			contact:  &tp.contacts[i],
 		}
 	}
 

--- a/processing/touch.go
+++ b/processing/touch.go
@@ -95,10 +95,8 @@ func (tp *TouchProcessor) Inputs(hm *Heatmap) []TouchInput {
 	GetPalms(tp.contacts, count)
 
 	for i := 0; i < count; i++ {
-		x, y := tp.contacts[i].Mean()
-
-		x /= float32(hm.Width - 1)
-		y /= float32(hm.Height - 1)
+		x := tp.contacts[i].X / float32(hm.Width-1)
+		y := tp.contacts[i].Y / float32(hm.Height-1)
 
 		if tp.InvertX {
 			x = 1 - x

--- a/processing/touch.go
+++ b/processing/touch.go
@@ -24,10 +24,13 @@ type TouchProcessor struct {
 }
 
 type TouchInput struct {
-	X      int
-	Y      int
-	Index  int
-	IsPalm bool
+	X        int
+	Y        int
+	Ev1      float32
+	Ev2      float32
+	Index    int
+	IsStable bool
+	IsPalm   bool
 
 	contact *Contact
 }
@@ -109,6 +112,8 @@ func (tp *TouchProcessor) Inputs(hm *Heatmap) []TouchInput {
 		tp.inputs[i] = TouchInput{
 			X:       int(x * 9600),
 			Y:       int(y * 7200),
+			Ev1:     tp.contacts[i].Ev1,
+			Ev2:     tp.contacts[i].Ev2,
 			Index:   i,
 			IsPalm:  tp.contacts[i].isPalm,
 			contact: &tp.contacts[i],
@@ -119,6 +124,8 @@ func (tp *TouchProcessor) Inputs(hm *Heatmap) []TouchInput {
 		tp.inputs[i] = TouchInput{
 			X:       0,
 			Y:       0,
+			Ev1:     0,
+			Ev2:     0,
 			Index:   -1,
 			contact: &tp.contacts[i],
 		}

--- a/processing/utils.go
+++ b/processing/utils.go
@@ -1,5 +1,7 @@
 package processing
 
+import "math"
+
 func Min(x int, y int) int {
 	if x < y {
 		return x
@@ -12,6 +14,18 @@ func Max(x int, y int) int {
 		return x
 	}
 	return y
+}
+
+func Abs(x float32) float32 {
+	return float32(math.Abs(float64(x)))
+}
+
+func Sqrt(x float32) float32 {
+	return float32(math.Sqrt(float64(x)))
+}
+
+func Hypot(x float32, y float32) float32 {
+	return float32(math.Hypot(float64(x), float64(y)))
 }
 
 /*

--- a/touch.go
+++ b/touch.go
@@ -23,7 +23,11 @@ func IptsTouchHandleHeatmap(ipts *IptsContext, heatmap *Heatmap) error {
 
 		touch.Device.Emit(EV_ABS, ABS_MT_SLOT, int32(i))
 
-		if p.IsPalm || !p.IsStable || blocked {
+		if p.Index != -1 && !p.IsStable {
+			continue
+		}
+
+		if p.IsPalm || blocked {
 			touch.Device.Emit(EV_ABS, ABS_MT_TRACKING_ID, -1)
 			touch.Device.Emit(EV_ABS, ABS_MT_POSITION_X, 0)
 			touch.Device.Emit(EV_ABS, ABS_MT_POSITION_Y, 0)

--- a/touch.go
+++ b/touch.go
@@ -23,7 +23,7 @@ func IptsTouchHandleHeatmap(ipts *IptsContext, heatmap *Heatmap) error {
 
 		touch.Device.Emit(EV_ABS, ABS_MT_SLOT, int32(i))
 
-		if p.IsPalm || blocked {
+		if p.IsPalm || !p.IsStable || blocked {
 			touch.Device.Emit(EV_ABS, ABS_MT_TRACKING_ID, -1)
 			touch.Device.Emit(EV_ABS, ABS_MT_POSITION_X, 0)
 			touch.Device.Emit(EV_ABS, ABS_MT_POSITION_Y, 0)


### PR DESCRIPTION
1. Use the eigenvalues of the covariance matrix to determine the shape of the touch instead of the variance across the axes. This improves accuracy when the touch is diagonal.
2. To avoid re-computation because of the above, store coordinates and covariance matrix eigenvalues and eigenvectors in the Contact struct, and the weighted sums used for their computation in a separate Cluster struct.
3. Lower the thresholds that designate a cluster as palm if the touch is light.
4. Handle thumb touches (long and thin) separately. This allow further lowering of palm thresholds.
5. Check how fast a cluster grows or shrinks. Ignore touches that grow or shrink too fast as unstable. This helps at the beginning when putting a palm down but the touch area is still small.
6. Lower the heatmap value back to 10 and reject pen tip by 0 variance instead, as it helped with 5. Can somebody test if this works, since my pen doesn't generate any heatmap events.

I'm also considering remembering palms for a short while after they've been lifted, so that if you lift it briefly and put it back down it still gets tracked, but let's get this reviewed first.

~~EDIT: This seems to hinders scrolling. Pretty sure it's a bug, not a fundamental issue with the idea, will update when fixed.~~ Now fixed.