### PR TITLE
Add tool to capture raw IPTS data

### DIFF
--- a/debug/capture.c
+++ b/debug/capture.c
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include <errno.h>
+#include <signal.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "src/control.h"
+#include "src/ipts.h"
+#include "src/protocol.h"
+#include "src/utils.h"
+
+struct iptsd_control ctrl;
+FILE *file = NULL;
+
+static void __exit(int error)
+{
+	int ret = iptsd_control_stop(&ctrl);
+	if (ret < 0)
+		iptsd_err(ret, "Failed to stop IPTS");
+
+	if (file)
+		fclose(file);
+
+	exit(error);
+}
+
+static void print_help(const char *pname)
+{
+	printf("%s - Dump IPTS data to binary file\n", pname);
+	printf("\n");
+	printf("Usage:\n");
+	printf("  %s <file>\n", pname);
+	printf("\n");
+	printf("Options:\n");
+	printf("  -h | --help    Show this help text\n");
+}
+
+int main(int argc, char **argv)
+{
+	signal(SIGINT, __exit);
+	signal(SIGTERM, __exit);
+	memset(&ctrl, 0, sizeof(struct iptsd_control));
+
+	if (argc != 2) {
+		printf("Invalid command line arguments:\n");
+		printf("  See '%s --help' for more information\n", argv[0]);
+		return 1;
+	}
+
+	if (!strcmp(argv[1], "-h") || !strcmp(argv[1], "--help")) {
+		print_help(argv[0]);
+		return 1;
+	}
+
+	int ret = iptsd_control_start(&ctrl);
+	if (ret < 0) {
+		iptsd_err(ret, "Failed to start IPTS");
+		return ret;
+	}
+
+	struct ipts_device_info info = ctrl.device_info;
+
+	printf("Vendor:       %04X\n", info.vendor);
+	printf("Product:      %04X\n", info.product);
+	printf("Version:      %u\n", info.version);
+	printf("Buffer Size:  %u\n", info.buffer_size);
+	printf("Max Contacts: %d\n", info.max_contacts);
+	printf("\n");
+
+	file = fopen(argv[1], "wb");
+
+	char *data = calloc(info.buffer_size, sizeof(char));
+	if (!data) {
+		iptsd_err(-ENOMEM, "Failed to allocate data buffer");
+		__exit(-ENOMEM);
+	}
+
+	while (true) {
+		int64_t doorbell = iptsd_control_doorbell(&ctrl);
+		if (doorbell < 0) {
+			iptsd_err(doorbell, "Failed to get doorbell");
+			__exit(doorbell);
+		}
+
+		if (doorbell <= ctrl.current_doorbell)
+			continue;
+
+		int ret = iptsd_control_read(&ctrl, data, info.buffer_size);
+		if (ret < 0) {
+			iptsd_err(ret, "Failed to read IPTS data");
+			__exit(ret);
+		}
+
+		size_t len = sizeof(struct ipts_data) + ((struct ipts_data *)data)->size;
+		fwrite(data, sizeof(char), len, file);
+
+		ret = iptsd_control_send_feedback(&ctrl);
+		if (ret < 0) {
+			iptsd_err(ret, "Failed to send feedback");
+			__exit(ret);
+		}
+	}
+
+	return 0;
+}

--- a/meson.build
+++ b/meson.build
@@ -57,6 +57,12 @@ sources_dbg = [
 	'src/utils.c',
 ]
 
+sources_capture = [
+	'debug/capture.c',
+	'src/control.c',
+	'src/utils.c',
+]
+
 deps = [
 	cc.find_library('m'),
 	dependency('inih', fallback: ['inih', 'inih_dep']),
@@ -113,4 +119,8 @@ endif
 
 if get_option('debug_tool')
 	executable('ipts-dbg', sources_dbg, install: true)
+endif
+
+if get_option('capture_tool')
+	executable('ipts-capture', sources_capture, install: true)
 endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,3 +1,4 @@
 option('systemd', type: 'boolean', value: true)
 option('sample_config', type: 'boolean', value: true)
 option('debug_tool', type: 'boolean', value: true)
+option('capture_tool', type: 'boolean', value: true)


### PR DESCRIPTION
Add a tool that can capture raw IPTS data and store it in a binary file for later analysis. This is fairly similar to (and based on) the debug tool that we already have, but instead of dumping it in a human-readable form, this tool will store the unprocessed binary data in a file, which makes it easier to analyze via e.g. python scripts. 