### PR TITLE
Add debug-tool option to capture raw IPTS data to binary file

### DIFF
--- a/debug/debug.c
+++ b/debug/debug.c
@@ -13,7 +13,7 @@
 #include "src/protocol.h"
 #include "src/utils.h"
 
-struct iptsd_control ctrl;
+static struct iptsd_control ctrl;
 
 static void __exit(int error)
 {


### PR DESCRIPTION
Add an option to the debug tool that can capture raw IPTS data and store it in a binary file for later analysis. Instead of dumping it in a human-readable form, this option will store the unprocessed binary data in a file, which makes it easier to analyze via e.g. python scripts.

Replaces #27.