### PR TITLE
Add openrc init script

### DIFF
--- a/etc/openrc/iptsd.initd.in
+++ b/etc/openrc/iptsd.initd.in
@@ -1,0 +1,15 @@
+#!/sbin/openrc-run
+
+description="Intel Precise Touch & Stylus daemon"
+command=@bindir@/iptsd
+
+# Add any arguments to pass to iptsd here
+command_args=""
+
+# Set the pid file location here
+# ${RC_SVCNAME} is set to the service name ("iptsd") when the script is run
+pidfile="/run/${RC_SVCNAME}.pid"
+
+# Set command_background to true if the daemon does not create a pidfile and
+# does not background itself. Start-stop-daemon will take care of these jobs.
+command_background="true"

--- a/meson.build
+++ b/meson.build
@@ -89,31 +89,11 @@ executable('iptsd', sources, dependencies: deps, install: true)
 install_data('etc/iptsd-reset-sensor', install_dir: bindir)
 install_subdir('config', install_dir: configdir, strip_directory: true)
 
-unitdir='' # If this remains empty, configure_file will skip the install step
-if get_option('systemd')
-	systemd = dependency('systemd')
-	unitdir = systemd.get_pkgconfig_variable('systemdsystemunitdir')
-
-	udev = dependency('udev')
-	udevdir = udev.get_pkgconfig_variable('udevdir')
-	rulesdir = join_paths(udevdir, 'rules.d')
-
-	install_data('etc/udev/50-ipts.rules', install_dir: rulesdir)
-endif
-
 configure_file(
 	input: 'etc/systemd/iptsd.service.in',
 	output: 'iptsd.service',
-	configuration: conf,
-	install_dir: unitdir
+	configuration: conf
 )
-
-openrcdir=''
-if get_option('openrc')
-	dependency('openrc')
-	install_openrc=true
-	openrcdir = join_paths(sysconfdir, 'init.d')
-endif
 
 configure_file(
 	input: 'etc/openrc/iptsd.initd.in',
@@ -121,8 +101,27 @@ configure_file(
 	configuration: conf
 )
 
-# Workaround required to rename iptsd.initd -> iptsd when installing
-if openrcdir != ''
+service_manager = get_option('service_manager')
+if service_manager.contains('systemd')
+	systemd = dependency('systemd')
+	unitdir = systemd.get_pkgconfig_variable('systemdsystemunitdir')
+
+	udev = dependency('udev')
+	udevdir = udev.get_pkgconfig_variable('udevdir')
+	rulesdir = join_paths(udevdir, 'rules.d')
+
+	install_data(
+		join_paths(meson.current_build_dir(), 'iptsd.service'),
+		install_dir: unitdir
+	)
+
+	install_data('etc/udev/50-ipts.rules', install_dir: rulesdir)
+endif
+
+if service_manager.contains('openrc')
+	dependency('openrc')
+	openrcdir = join_paths(sysconfdir, 'init.d')
+
 	install_data(
 		join_paths(meson.current_build_dir(), 'iptsd.initd'),
 		install_dir: openrcdir,

--- a/meson.build
+++ b/meson.build
@@ -89,6 +89,7 @@ executable('iptsd', sources, dependencies: deps, install: true)
 install_data('etc/iptsd-reset-sensor', install_dir: bindir)
 install_subdir('config', install_dir: configdir, strip_directory: true)
 
+unitdir='' # If this remains empty, configure_file will skip the install step
 if get_option('systemd')
 	systemd = dependency('systemd')
 	unitdir = systemd.get_pkgconfig_variable('systemdsystemunitdir')
@@ -97,15 +98,36 @@ if get_option('systemd')
 	udevdir = udev.get_pkgconfig_variable('udevdir')
 	rulesdir = join_paths(udevdir, 'rules.d')
 
-	configure_file(
-		input: 'etc/systemd/iptsd.service.in',
-		output: 'iptsd.service',
-		configuration: conf,
-		install: true,
-		install_dir: unitdir,
-	)
-
 	install_data('etc/udev/50-ipts.rules', install_dir: rulesdir)
+endif
+
+configure_file(
+	input: 'etc/systemd/iptsd.service.in',
+	output: 'iptsd.service',
+	configuration: conf,
+	install_dir: unitdir
+)
+
+openrcdir=''
+if get_option('openrc')
+	dependency('openrc')
+	install_openrc=true
+	openrcdir = join_paths(sysconfdir, 'init.d')
+endif
+
+configure_file(
+	input: 'etc/openrc/iptsd.initd.in',
+	output: 'iptsd.initd',
+	configuration: conf
+)
+
+# Workaround required to rename iptsd.initd -> iptsd when installing
+if openrcdir != ''
+	install_data(
+		join_paths(meson.current_build_dir(), 'iptsd.initd'),
+		install_dir: openrcdir,
+		rename: 'iptsd'
+	)
 endif
 
 if get_option('sample_config')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,3 +1,4 @@
 option('systemd', type: 'boolean', value: true)
+option('openrc', type: 'boolean', value: false)
 option('sample_config', type: 'boolean', value: true)
 option('debug_tool', type: 'boolean', value: true)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,4 +1,8 @@
-option('systemd', type: 'boolean', value: true)
-option('openrc', type: 'boolean', value: false)
+option(
+	'service_manager',
+	type: 'array',
+	choices: ['systemd', 'openrc'],
+	value: ['systemd']
+)
 option('sample_config', type: 'boolean', value: true)
 option('debug_tool', type: 'boolean', value: true)


### PR DESCRIPTION
What the commits change:
1. Add an init script for the openrc service manager.
2. Change ```meson.build``` so that it can configure and install the new script automatically. The new script is _always_ configured via meson, but whether or not the script is installed depends on ```-Dopenrc=true/false```.
3. Update the systemd portion of ```meson.build``` so that the service file is also always configured. As with the openrc script, only installation is controlled by ```-Dsystemd=true/false```. This change allows the daemon to be more easily packaged for Gentoo.

Notes:
- I considered merging the systemd and openrc options into one option (say ```-Dservice_manager``` for example) which would be an array instead of a boolean. This might help in the future if someone submits a patch for another service manager because you could just add it to the array of options. Let me know if that sounds like a good idea and I'll update the PR.