### PR TITLE
Add config for C variant of SP4 (1B96:0023)

### DIFF
--- a/config/surface-pro4-c.conf
+++ b/config/surface-pro4-c.conf
@@ -1,0 +1,11 @@
+[Device]
+Vendor = 0x1B96
+Product = 0x0023
+
+[Config]
+# Needs to be verified by a device owner
+InvertX = true
+InvertY = true
+
+Width = 2598
+Height = 1732


### PR DESCRIPTION
Hi, I've recently bought a surface pro 4, and iptsd crashed because my touchscreen identifies itself as 1B96:0023.

Adding in this extra config fixes the touchscreen for me.

Thanks,
Rhys.