### PR TITLE
Add config file for Surface Pro X SQ2

### DIFF
--- a/etc/config/surface-proX.conf
+++ b/etc/config/surface-proX.conf
@@ -1,0 +1,10 @@
+[Device]
+Vendor = 0x045E
+Product = 0x0C21
+
+[Config]
+InvertX = false
+InvertY = false
+
+Width = 2598
+Height = 1732


### PR DESCRIPTION
I assume the Surface Pro X SQ1 uses the same HID device ID as the SQ2.