### PR TITLE
Add tilt support to DFT processor

### DIFF
--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -128,6 +128,15 @@ static int parse_conf(void *user, const char *c_section, const char *c_name, con
 	if (section == "DFT" && name == "FreqMinMag")
 		config->dft_freq_min_mag = std::stoi(value);
 
+	if (section == "DFT" && name == "TiltMinMag")
+		config->dft_tilt_min_mag = std::stoi(value);
+
+	if (section == "DFT" && name == "TiltDistance")
+		config->dft_tilt_distance = std::stof(value);
+
+	if (section == "DFT" && name == "TipDistance")
+		config->dft_tip_distance = std::stof(value);
+
 	return 1;
 }
 

--- a/src/config/config.hpp
+++ b/src/config/config.hpp
@@ -50,6 +50,9 @@ public:
 	f32 dft_position_exp = -0.7;
 	u16 dft_button_min_mag = 1000;
 	u16 dft_freq_min_mag = 10000;
+	u16 dft_tilt_min_mag = 10000;
+	f32 dft_tilt_distance = 6;
+	f32 dft_tip_distance = 2;
 
 public:
 	Config(i16 vendor, i16 product);

--- a/src/config/config.hpp
+++ b/src/config/config.hpp
@@ -51,8 +51,8 @@ public:
 	u16 dft_button_min_mag = 1000;
 	u16 dft_freq_min_mag = 10000;
 	u16 dft_tilt_min_mag = 10000;
-	f32 dft_tilt_distance = 6;
-	f32 dft_tip_distance = 2;
+	f32 dft_tilt_distance = 0.6;
+	f32 dft_tip_distance = 0;
 
 public:
 	Config(i16 vendor, i16 product);

--- a/src/daemon/dft.cpp
+++ b/src/daemon/dft.cpp
@@ -192,8 +192,8 @@ static void iptsd_dft_handle_position(Context &ctx, const ipts::DftWindow &dft,
 				xt *= ctx.config.width * 10 / ctx.config.dft_tilt_distance;
 				yt *= ctx.config.height * 10 / ctx.config.dft_tilt_distance;
 
-				auto azm = std::max(0., std::fmod(std::atan2(-yt, xt) / M_PI + 2, 2)) * 18000;
-				auto alt = (.5 - std::acos(std::min(1., std::hypot(xt, yt))) / M_PI) * 18000;
+				auto azm = std::fmod(std::atan2(-yt, xt) / M_PI + 2, 2) * 18000;
+				auto alt = std::asin(std::min(1.0, std::hypot(xt, yt))) / M_PI * 18000;
 				stylus.azimuth = gsl::narrow<u16>(std::round(azm));
 				stylus.altitude = gsl::narrow<u16>(std::round(alt));
 

--- a/src/daemon/dft.cpp
+++ b/src/daemon/dft.cpp
@@ -189,8 +189,8 @@ static void iptsd_dft_handle_position(Context &ctx, const ipts::DftWindow &dft,
 					y -= yt * r;
 				}
 
-				xt *= ctx.config.width / (ctx.config.dft_tilt_distance * 10);
-				yt *= ctx.config.height / (ctx.config.dft_tilt_distance * 10);
+				xt *= ctx.config.width * 10 / ctx.config.dft_tilt_distance;
+				yt *= ctx.config.height * 10 / ctx.config.dft_tilt_distance;
 
 				auto azm = std::max(0., std::fmod(std::atan2(-yt, xt) / M_PI + 2, 2)) * 18000;
 				auto alt = (.5 - std::acos(std::min(1., std::hypot(xt, yt))) / M_PI) * 18000;

--- a/src/daemon/dft.cpp
+++ b/src/daemon/dft.cpp
@@ -63,6 +63,9 @@ iptsd_dft_interpolate_position(const Context &ctx, const struct ipts_pen_dft_win
 	// find critical point of fitted parabola
 	f64 d = (x[0] - x[2]) / (2 * (x[0] - 2 * x[1] + x[2]));
 
+	if (std::isnan(d))
+		return std::tuple {false, 0};
+
 	return std::tuple {true, row.first + maxi + std::clamp(d, mind, maxd)};
 }
 

--- a/src/daemon/dft.cpp
+++ b/src/daemon/dft.cpp
@@ -192,8 +192,8 @@ static void iptsd_dft_handle_position(Context &ctx, const ipts::DftWindow &dft,
 					y -= yt * r;
 				}
 
-				xt *= ctx.config.width * 10 / ctx.config.dft_tilt_distance;
-				yt *= ctx.config.height * 10 / ctx.config.dft_tilt_distance;
+				xt *= ctx.config.width / ctx.config.dft_tilt_distance;
+				yt *= ctx.config.height / ctx.config.dft_tilt_distance;
 
 				auto azm = std::fmod(std::atan2(-yt, xt) / M_PI + 2, 2) * 18000;
 				auto alt = std::asin(std::min(1.0, std::hypot(xt, yt))) / M_PI * 18000;

--- a/src/daemon/dft.cpp
+++ b/src/daemon/dft.cpp
@@ -129,7 +129,7 @@ static f64 iptsd_dft_interpolate_frequency(const Context &ctx, const ipts::DftWi
 static void iptsd_dft_handle_position(Context &ctx, const ipts::DftWindow &dft,
 				      ipts::StylusData &stylus)
 {
-	if (dft.rows <= 0) {
+	if (dft.rows <= 1) {
 		iptsd_dft_lift(stylus);
 		return;
 	}
@@ -159,6 +159,47 @@ static void iptsd_dft_handle_position(Context &ctx, const ipts::DftWindow &dft,
 
 		if (ctx.config.invert_y)
 			y = 1 - y;
+
+		if (dft.x[1].magnitude > ctx.config.dft_tilt_min_mag &&
+		    dft.y[1].magnitude > ctx.config.dft_tilt_min_mag) {
+
+			// calculate tilt angle from relative position of secondary transmitter
+
+			auto [pxt, xt] = iptsd_dft_interpolate_position(ctx, dft.x[1]);
+			auto [pyt, yt] = iptsd_dft_interpolate_position(ctx, dft.y[1]);
+
+			if (pxt && pyt) {
+
+				xt /= dft.dim.width - 1;
+				yt /= dft.dim.height - 1;
+
+				if (ctx.config.invert_x)
+					xt = 1 - xt;
+
+				if (ctx.config.invert_y)
+					yt = 1 - yt;
+
+				xt -= x;
+				yt -= y;
+
+				if (ctx.config.dft_tip_distance) {
+					// correct tip position using tilt data
+					auto r = ctx.config.dft_tip_distance / ctx.config.dft_tilt_distance;
+					x -= xt * r;
+					y -= yt * r;
+				}
+
+				xt *= ctx.config.width / (ctx.config.dft_tilt_distance * 10);
+				yt *= ctx.config.height / (ctx.config.dft_tilt_distance * 10);
+
+				auto azm = std::max(0., std::fmod(std::atan2(-yt, xt) / M_PI + 2, 2)) * 18000;
+				auto alt = (.5 - std::acos(std::min(1., std::hypot(xt, yt))) / M_PI) * 18000;
+				stylus.azimuth = gsl::narrow<u16>(std::round(azm));
+				stylus.altitude = gsl::narrow<u16>(std::round(alt));
+
+			}
+
+		}
 
 		x = std::round(std::clamp(x, 0.0, 1.0) * IPTS_MAX_X);
 		y = std::round(std::clamp(y, 0.0, 1.0) * IPTS_MAX_Y);


### PR DESCRIPTION
See https://github.com/quo/iptsd/issues/3#issuecomment-1164732835.

The basic idea is that there is a secondary transmitter about 6mm behind the primary transmitter in the pen. Tilt is calculated from the difference in positions of the signals from the two transmitters. I assume the distance between the transmitters is 6mm for all pens, but it's possible that the distance is encoded in the unknown binary signals somehow. Note that tilt data is only transmitted when the pen is touching the screen, not while hovering.

Additionally, if the distance between the tip of the pen and the primary transmitter is known, the tilt data can be used to calculate the actual tip position. I've guessed this distance to be 2mm based on behavior of my non-tilt pen, and added a correction for it, but the distance may be slightly different for each pen. Since tilt is not transmitted while hovering, with this correction the cursor will shift slightly when the pen starts or stops touching the screen, which may be undesirable.

Since I don't have a pen with tilt support myself, someone who does (@qzed?) should test these changes before they are merged. (I hope I got the azimuth/altitude calculations right, but it's very possible the azimuth will need to be mirrored or rotated further.)

For the tip position correction, please check if the 2mm value works, or if you need to adjust this up or down. Also, please compare the behavior with the tip distance set to 0, especially with things like slow diagonal movements. Is the additional noise from the tilt data (that is added to the position when tip distance is nonzero) noticeable?