### PR TITLE
Fix some systemd warnings about unescaped arguments

### DIFF
--- a/etc/systemd/iptsd@.service.in
+++ b/etc/systemd/iptsd@.service.in
@@ -2,7 +2,7 @@
 Description=Intel Precise Touch & Stylus Daemon
 Documentation=https://github.com/linux-surface/iptsd
 StopWhenUnneeded=yes
-BindsTo=%I
+BindsTo=%i.device
 
 [Service]
 Type=simple

--- a/etc/udev/50-ipts.rules
+++ b/etc/udev/50-ipts.rules
@@ -1,3 +1,11 @@
-SUBSYSTEM=="hidraw", DRIVERS=="ipts", TAG+="systemd", ENV{SYSTEMD_WANTS}+="iptsd@$env{DEVNAME}.service"
-SUBSYSTEM=="hidraw", DRIVERS=="ithc", TAG+="systemd", ENV{SYSTEMD_WANTS}+="iptsd@$env{DEVNAME}.service"
-SUBSYSTEM=="hidraw", DRIVERS=="spi_hid", TAG+="systemd", ENV{SYSTEMD_WANTS}+="iptsd@$env{DEVNAME}.service"
+SUBSYSTEM=="hidraw", DRIVERS=="ipts", TAG+="systemd", \
+    PROGRAM="/bin/systemd-escape --path $env{DEVNAME}" \
+    ENV{SYSTEMD_WANTS}+="iptsd@$result.service"
+
+SUBSYSTEM=="hidraw", DRIVERS=="ithc", TAG+="systemd", \
+    PROGRAM="/bin/systemd-escape --path $env{DEVNAME}" \
+    ENV{SYSTEMD_WANTS}+="iptsd@$result.service"
+
+SUBSYSTEM=="hidraw", DRIVERS=="spi_hid", TAG+="systemd", \
+    PROGRAM="/bin/systemd-escape --path $env{DEVNAME}" \
+    ENV{SYSTEMD_WANTS}+="iptsd@$result.service"


### PR DESCRIPTION
Systemd complains about unescaped arguments to the service. So escape them properly.