### PR TITLE
Update action to fix deprecation warning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,7 +187,7 @@ jobs:
         path: fedora-36-latest
 
     - name: Upload assets
-      uses: svenstaro/upload-release-action@v1-release
+      uses: svenstaro/upload-release-action@v2
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
         file: ./*-latest/*


### PR DESCRIPTION
Update "svenstaro/upload-release-action" to v2 to fix deprecation warnings about Node 12.