### PR TITLE
Improve statistics of iptsd-perf

### DIFF
--- a/src/contacts/finder.cpp
+++ b/src/contacts/finder.cpp
@@ -62,6 +62,16 @@ void ContactFinder::resize(index2_t size)
 		this->detector = std::make_unique<advanced::BlobDetector>(size, config);
 }
 
+void ContactFinder::reset()
+{
+	for (std::size_t i = 0; i < config.temporal_window; i++) {
+		std::size_t size = this->frames[i].size();
+
+		for (std::size_t j = 0; j < size; j++)
+			this->frames[i][j].active = false;
+	}
+}
+
 bool ContactFinder::check_valid(const Contact &contact)
 {
 	f64 aspect = contact.major / contact.minor;

--- a/src/contacts/finder.hpp
+++ b/src/contacts/finder.hpp
@@ -81,6 +81,7 @@ public:
 	const std::vector<Contact> &search();
 
 	void resize(index2_t size);
+	void reset();
 
 private:
 	bool check_valid(const Contact &contact);

--- a/src/debug/perf.cpp
+++ b/src/debug/perf.cpp
@@ -52,10 +52,13 @@ static int main(gsl::span<char *> args)
 {
 	CLI::App app {};
 	std::filesystem::path path;
+	u32 runs = 10;
 
 	app.add_option("DATA", path, "The binary data file containing the data to test.")
 		->type_name("FILE")
 		->required();
+	app.add_option("RUNS", runs, "Repeat this number of runs through the data.")
+		->check(CLI::Range(1, 1000));
 
 	CLI11_PARSE(app, args.size(), args.data());
 
@@ -133,8 +136,7 @@ static int main(gsl::span<char *> args)
 		had_heatmap = true;
 	};
 
-	static constexpr u32 LOOP_COUNT = 10;
-	for (u32 i = 0; i < LOOP_COUNT; i++) {
+	for (u32 i = 0; i < runs; i++) {
 		finder.reset();
 		reader_finished_successfully = false;
 		gsl::span<u8> reader(buffer.data(), buffer.size());

--- a/src/debug/perf.cpp
+++ b/src/debug/perf.cpp
@@ -125,17 +125,17 @@ static int main(gsl::span<char *> args)
 	bool reader_finished_successfully = false;
 
 	// Parser is idempotent but ContactFinder is not
-	std::optional<contacts::ContactFinder> finder {std::nullopt};
+	contacts::ContactFinder finder {config.contacts()};
 	ipts::Parser parser {};
 	parser.on_heatmap = [&](const auto &data) {
-		iptsd_perf_handle_input(*finder, data);
+		iptsd_perf_handle_input(finder, data);
 		// Don't track time for non-heatmap
 		had_heatmap = true;
 	};
 
 	static constexpr u32 LOOP_COUNT = 10;
 	for (u32 i = 0; i < LOOP_COUNT; i++) {
-		finder.emplace(config.contacts());
+		finder.reset();
 		reader_finished_successfully = false;
 		gsl::span<u8> reader(buffer.data(), buffer.size());
 		while (true) {
@@ -184,7 +184,6 @@ static int main(gsl::span<char *> args)
 				continue;
 			}
 		}
-		finder.reset();
 	}
 	// This is outside the loop to not spam the user
 	// as it will be set to the same value every iteration of the loop

--- a/src/debug/perf.cpp
+++ b/src/debug/perf.cpp
@@ -105,50 +105,102 @@ static int main(gsl::span<char *> args)
 	if (config.width == 0 || config.height == 0)
 		throw std::runtime_error("No display config for this device was found!");
 
-	contacts::ContactFinder finder {config.contacts()};
+	// Read the file into memory to eliminate filesystem access as a variable
+	std::noskipws(ifs);
+	std::vector<u8> buffer {std::istream_iterator<u8>(ifs), std::istream_iterator<u8>()};
+	ifs = {};
 
+	using clock = std::chrono::high_resolution_clock;
+	using std::chrono::duration_cast;
+	using micros_u64 = std::chrono::duration<u64, std::micro>;
+	using micros_f64 = std::chrono::duration<f64, std::micro>;
+
+	u64 total = 0;
+	u64 total_of_squares = 0;
+	u32 count = 0;
+
+	auto min = clock::duration::max();
+	auto max = clock::duration::min();
+	bool had_heatmap = false;
+	bool reader_finished_successfully = false;
+
+	// Parser is idempotent but ContactFinder is not
+	std::optional<contacts::ContactFinder> finder {std::nullopt};
 	ipts::Parser parser {};
-	parser.on_heatmap = [&](const auto &data) { iptsd_perf_handle_input(finder, data); };
+	parser.on_heatmap = [&](const auto &data) {
+		iptsd_perf_handle_input(*finder, data);
+		// Don't track time for non-heatmap
+		had_heatmap = true;
+	};
 
-	std::vector<u8> buffer(header.buffer_size);
-	std::vector<f64> measurements {};
+	static constexpr u32 LOOP_COUNT = 10;
+	for (u32 i = 0; i < LOOP_COUNT; i++) {
+		finder.emplace(config.contacts());
+		reader_finished_successfully = false;
+		gsl::span<u8> reader(buffer.data(), buffer.size());
+		while (true) {
+			try {
+				if (reader.empty()) {
+					reader_finished_successfully = true;
+					break;
+				}
 
-	while (ifs.peek() != EOF) {
-		try {
-			ssize_t size = 0;
+				size_t size = 0;
+				if (reader.size() < sizeof(size))
+					break;
+				std::memcpy(&size, reader.data(), sizeof(size));
+				reader = reader.subspan(sizeof(size));
 
-			// NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-			ifs.read(reinterpret_cast<char *>(&size), sizeof(size));
+				if (reader.size() < size)
+					break;
+				if (size > header.buffer_size)
+					break;
+				gsl::span<u8> data = reader.subspan(0, size);
+				reader = reader.subspan(header.buffer_size);
 
-			// NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-			ifs.read(reinterpret_cast<char *>(buffer.data()),
-				 gsl::narrow<std::streamsize>(buffer.size()));
+				// Take start time
+				auto start = clock::now();
 
-			// Take start time
-			auto start = std::chrono::high_resolution_clock::now();
+				// Send the report to the finder through the parser for processing
+				// Cannot put this in a loop because it is not a pure function
+				// as it has things like temporal averaging
+				parser.parse(data);
 
-			parser.parse(gsl::span<u8>(buffer.data(), size));
+				if (std::exchange(had_heatmap, false)) {
+					// Take end time
+					auto end = clock::now();
 
-			// Take end time
-			auto end = std::chrono::high_resolution_clock::now();
-
-			// Save measurement
-			measurements.push_back(gsl::narrow<f64>((end - start).count()));
-		} catch (std::exception &e) {
-			spdlog::warn(e.what());
-			continue;
+					clock::duration x_ns = end - start;
+					// Divide early for x and x**2 because they are overflowing
+					u64 x_us = duration_cast<micros_u64>(x_ns).count();
+					total += x_us;
+					total_of_squares += x_us * x_us;
+					min = std::min(min, x_ns);
+					max = std::max(max, x_ns);
+					++count;
+				}
+			} catch (std::exception &e) {
+				spdlog::warn(e.what());
+				continue;
+			}
 		}
+		finder.reset();
 	}
+	// This is outside the loop to not spam the user
+	// as it will be set to the same value every iteration of the loop
+	if (!reader_finished_successfully)
+		spdlog::warn("Leftover data at end of input");
 
-	auto total = container::ops::sum(measurements);
-	auto [min, max] = container::ops::minmax(measurements);
+	f64 n = gsl::narrow<f64>(count);
+	f64 mean = gsl::narrow<f64>(total) / n;
+	f64 stddev = std::sqrt(gsl::narrow<f64>(total_of_squares) / n - mean * mean);
 
-	f64 average = total / gsl::narrow<f64>(measurements.size());
-
-	spdlog::info("Total:   {:.3f}μs", total / 1000);
-	spdlog::info("Average: {:.3f}μs", average / 1000);
-	spdlog::info("Minimum: {:.3f}μs", min / 1000);
-	spdlog::info("Maximum: {:.3f}μs", max / 1000);
+	spdlog::info("Ran {} times", count);
+	spdlog::info("Total: {}μs", total);
+	spdlog::info("Mean: {:.2f}μs", mean);
+	spdlog::info("Standard Deviation: {:.2f}μs", stddev);
+	spdlog::info("Minimum: {:.3f}μs", duration_cast<micros_f64>(min).count());
+	spdlog::info("Maximum: {:.3f}μs", duration_cast<micros_f64>(max).count());
 
 	return 0;
 }


### PR DESCRIPTION
This PR aims to improve the statistical behavior of `iptsd-perf` a bit:

- Add standard deviation
- Repeat multiple times
- Exclude non-heatmap reports
- Read the whole file into memory to eliminate variability from filesystem access
- Accumulate the values instead of facing reallocations from saving to a vector
- Use integers instead of floats for accumulation to avoid inprecision from order-dependent behavior of floats
- Use std::chrono::duration_cast for portability
- Detect malformed input

# Before

<details>

```
home@daniel-desktop3:~/CLionProjects/iptsd/build/src/debug$ ./iptsd-perf ../../../../iptsdump.dat 
[04:25:32.892] [info] Vendor:       045E
[04:25:32.892] [info] Product:      099F
[04:25:32.892] [info] Buffer Size:  7487
[04:25:32.892] [info] Metadata:
[04:25:32.892] [info] rows=44, columns=64
[04:25:32.892] [info] width=25978, height=17319
[04:25:32.892] [info] transform=[-412.3492,0,25978,0,-402.76746,17319]
[04:25:32.892] [info] unknown=1, [178,182,180,1,178,182,180,1,90,171,100,20,172,177,175,2]
[04:25:32.895] [info] Total:   2774.511μs
[04:25:32.895] [info] Average: 13.149μs
[04:25:32.895] [info] Minimum: 0.130μs
[04:25:32.895] [info] Maximum: 23.970μs
home@daniel-desktop3:~/CLionProjects/iptsd/build/src/debug$ ./iptsd-perf ../../../../iptsdump.dat 
[04:25:40.347] [info] Vendor:       045E
[04:25:40.347] [info] Product:      099F
[04:25:40.347] [info] Buffer Size:  7487
[04:25:40.347] [info] Metadata:
[04:25:40.347] [info] rows=44, columns=64
[04:25:40.347] [info] width=25978, height=17319
[04:25:40.347] [info] transform=[-412.3492,0,25978,0,-402.76746,17319]
[04:25:40.347] [info] unknown=1, [178,182,180,1,178,182,180,1,90,171,100,20,172,177,175,2]
[04:25:40.352] [info] Total:   4143.332μs
[04:25:40.352] [info] Average: 19.637μs
[04:25:40.352] [info] Minimum: 0.280μs
[04:25:40.352] [info] Maximum: 49.830μs
home@daniel-desktop3:~/CLionProjects/iptsd/build/src/debug$ ./iptsd-perf ../../../../iptsdump.dat 
[04:25:41.029] [info] Vendor:       045E
[04:25:41.029] [info] Product:      099F
[04:25:41.029] [info] Buffer Size:  7487
[04:25:41.029] [info] Metadata:
[04:25:41.029] [info] rows=44, columns=64
[04:25:41.029] [info] width=25978, height=17319
[04:25:41.029] [info] transform=[-412.3492,0,25978,0,-402.76746,17319]
[04:25:41.029] [info] unknown=1, [178,182,180,1,178,182,180,1,90,171,100,20,172,177,175,2]
[04:25:41.032] [info] Total:   3194.851μs
[04:25:41.032] [info] Average: 15.141μs
[04:25:41.032] [info] Minimum: 0.280μs
[04:25:41.032] [info] Maximum: 48.470μs
home@daniel-desktop3:~/CLionProjects/iptsd/build/src/debug$ ./iptsd-perf ../../../../iptsdump.dat 
[04:25:41.548] [info] Vendor:       045E
[04:25:41.548] [info] Product:      099F
[04:25:41.548] [info] Buffer Size:  7487
[04:25:41.548] [info] Metadata:
[04:25:41.548] [info] rows=44, columns=64
[04:25:41.548] [info] width=25978, height=17319
[04:25:41.548] [info] transform=[-412.3492,0,25978,0,-402.76746,17319]
[04:25:41.548] [info] unknown=1, [178,182,180,1,178,182,180,1,90,171,100,20,172,177,175,2]
[04:25:41.552] [info] Total:   3536.361μs
[04:25:41.552] [info] Average: 16.760μs
[04:25:41.552] [info] Minimum: 0.210μs
[04:25:41.552] [info] Maximum: 48.270μs
home@daniel-desktop3:~/CLionProjects/iptsd/build/src/debug$ ./iptsd-perf ../../../../iptsdump.dat 
[04:25:42.107] [info] Vendor:       045E
[04:25:42.107] [info] Product:      099F
[04:25:42.107] [info] Buffer Size:  7487
[04:25:42.107] [info] Metadata:
[04:25:42.107] [info] rows=44, columns=64
[04:25:42.107] [info] width=25978, height=17319
[04:25:42.107] [info] transform=[-412.3492,0,25978,0,-402.76746,17319]
[04:25:42.107] [info] unknown=1, [178,182,180,1,178,182,180,1,90,171,100,20,172,177,175,2]
[04:25:42.111] [info] Total:   3853.412μs
[04:25:42.111] [info] Average: 18.263μs
[04:25:42.111] [info] Minimum: 0.210μs
[04:25:42.111] [info] Maximum: 36.130μs
home@daniel-desktop3:~/CLionProjects/iptsd/build/src/debug$ ./iptsd-perf ../../../../iptsdump.dat 
[04:25:42.819] [info] Vendor:       045E
[04:25:42.819] [info] Product:      099F
[04:25:42.819] [info] Buffer Size:  7487
[04:25:42.819] [info] Metadata:
[04:25:42.819] [info] rows=44, columns=64
[04:25:42.819] [info] width=25978, height=17319
[04:25:42.819] [info] transform=[-412.3492,0,25978,0,-402.76746,17319]
[04:25:42.819] [info] unknown=1, [178,182,180,1,178,182,180,1,90,171,100,20,172,177,175,2]
[04:25:42.823] [info] Total:   3897.692μs
[04:25:42.823] [info] Average: 18.472μs
[04:25:42.823] [info] Minimum: 0.210μs
[04:25:42.823] [info] Maximum: 38.470μs
home@daniel-desktop3:~/CLionProjects/iptsd/build/src/debug$ ./iptsd-perf ../../../../iptsdump.dat 
[04:25:43.787] [info] Vendor:       045E
[04:25:43.787] [info] Product:      099F
[04:25:43.787] [info] Buffer Size:  7487
[04:25:43.787] [info] Metadata:
[04:25:43.787] [info] rows=44, columns=64
[04:25:43.787] [info] width=25978, height=17319
[04:25:43.787] [info] transform=[-412.3492,0,25978,0,-402.76746,17319]
[04:25:43.787] [info] unknown=1, [178,182,180,1,178,182,180,1,90,171,100,20,172,177,175,2]
[04:25:43.792] [info] Total:   4129.942μs
[04:25:43.792] [info] Average: 19.573μs
[04:25:43.792] [info] Minimum: 0.280μs
[04:25:43.792] [info] Maximum: 49.800μs
```
</details>

The `average` is confusingly all over the place.

# After

The mean is much more consistent now:

```
/home/home/CLionProjects/iptsd/build/src/debug/iptsd-perf ./iptsdump.dat
[07:55:47.757] [info] Vendor:       045E
[07:55:47.757] [info] Product:      099F
[07:55:47.757] [info] Buffer Size:  7487
[07:55:47.757] [info] Metadata:
[07:55:47.757] [info] rows=44, columns=64
[07:55:47.757] [info] width=25978, height=17319
[07:55:47.757] [info] transform=[-412.3492,0,25978,0,-402.76746,17319]
[07:55:47.757] [info] unknown=1, [178,182,180,1,178,182,180,1,90,171,100,20,172,177,175,2]
[07:55:47.795] [info] Ran 2010 times
[07:55:47.795] [info] Total: 28143μs
[07:55:47.795] [info] Mean: 14.00μs
[07:55:47.795] [info] Standard Deviation: 0.62μs
[07:55:47.795] [info] Minimum: 13.830μs
[07:55:47.795] [info] Maximum: 24.550μs
```

There is another run with the advanced instead of basic detection. I would have set `LOOP_COUNT` to 1000 not 10, but the advanced algorithm would take too long. Here it is below:

```
/home/home/CLionProjects/iptsd/build/src/debug/iptsd-perf ./iptsdump.dat
[08:03:23.027] [info] Vendor:       045E
[08:03:23.027] [info] Product:      099F
[08:03:23.027] [info] Buffer Size:  7487
[08:03:23.027] [info] Metadata:
[08:03:23.027] [info] rows=44, columns=64
[08:03:23.027] [info] width=25978, height=17319
[08:03:23.027] [info] transform=[-412.3492,0,25978,0,-402.76746,17319]
[08:03:23.027] [info] unknown=1, [178,182,180,1,178,182,180,1,90,171,100,20,172,177,175,2]
[08:03:29.048] [info] Ran 2010 times
[08:03:29.048] [info] Total: 6011079μs
[08:03:29.048] [info] Mean: 2990.59μs
[08:03:29.048] [info] Standard Deviation: 1045.43μs
[08:03:29.048] [info] Minimum: 147.510μs
[08:03:29.048] [info] Maximum: 5385.695μs
```

From the new perf display, we can learn that the advanced detection has a much higher variance-to-mean ratio than the basic detection.