### PR TITLE
Optimize advanced detector by 34% in perf

### DIFF
--- a/src/contacts/advanced/algorithm/distance_transform.hpp
+++ b/src/contacts/advanced/algorithm/distance_transform.hpp
@@ -75,20 +75,14 @@ auto is_compute(B& bin, M& mask, index_t i) -> bool
     return !is_foreground(bin, i) && !is_masked(mask, i);
 }
 
-template<typename V, typename T>
-auto get_cost(T& cost, index_t i, index2_t d) -> V
-{
-    return cost(i, d);
-}
-
-template<typename T, typename Q, typename B, typename M, typename C>
+template<index_t DX, index_t DY, typename T, typename Q, typename B, typename M, typename C>
 inline void evaluate(Image<T>& out, Q& queue, B& bin, M& mask, C& cost, index_t i,
-                     index_t stride, index2_t dir, T limit)
+                     index_t stride, T limit)
 {
     if (!is_compute(bin, mask, i + stride))
         return;
 
-    auto const c = out[i] + get_cost<T>(cost, i, dir);
+    auto const c = out[i] + cost.template get_cost<DX, DY>(i);
 
     if (c < out[i + stride] && c < limit) {
         queue.push({ i + stride, c });
@@ -104,7 +98,6 @@ void weighted_distance_transform(Image<T>& out, F& bin, M& mask, C& cost, Q& q,
                                  T limit=std::numeric_limits<T>::max())
 {
     using wdt::impl::evaluate;
-    using wdt::impl::get_cost;
     using wdt::impl::is_foreground;
     using wdt::impl::is_masked;
 
@@ -131,15 +124,15 @@ void weighted_distance_transform(Image<T>& out, F& bin, M& mask, C& cost, Q& q,
             auto c = std::numeric_limits<T>::max();
 
             if (is_foreground(bin, i + s_right)) {
-                c = std::min(c, get_cost<T>(cost, i + s_right, { -1, 0 }));
+                c = std::min(c, cost.template get_cost<-1, 0>(i + s_right));
             }
 
             if (is_foreground(bin, i + s_bot)) {
-                c = std::min(c, get_cost<T>(cost, i + s_bot, { 0, -1 }));
+                c = std::min(c, cost.template get_cost<0, -1>(i + s_bot));
             }
 
             if (N == 8 && is_foreground(bin, i + s_bot_right)) {
-                c = std::min(c, get_cost<T>(cost, i + s_bot_right, { -1, -1 }));
+                c = std::min(c, cost.template get_cost<-1, -1>(i + s_bot_right));
             }
 
             if (c < limit) {
@@ -166,23 +159,23 @@ void weighted_distance_transform(Image<T>& out, F& bin, M& mask, C& cost, Q& q,
         auto c = std::numeric_limits<T>::max();
 
         if (is_foreground(bin, i + s_left)) {
-            c = std::min(c, get_cost<T>(cost, i + s_left, { 1, 0 }));
+            c = std::min(c, cost.template get_cost<1, 0>(i + s_left));
         }
 
         if (is_foreground(bin, i + s_right)) {
-            c = std::min(c, get_cost<T>(cost, i + s_right, { -1, 0 }));
+            c = std::min(c, cost.template get_cost<-1, 0>(i + s_right));
         }
 
         if (N == 8 && is_foreground(bin, i + s_bot_left)) {
-            c = std::min(c, get_cost<T>(cost, i + s_bot_left, { 1, -1 }));
+            c = std::min(c, cost.template get_cost<1, -1>(i + s_bot_left));
         }
 
         if (is_foreground(bin, i + s_bot)) {
-            c = std::min(c, get_cost<T>(cost, i + s_bot, { 0, -1 }));
+            c = std::min(c, cost.template get_cost<0, -1>(i + s_bot));
         }
 
         if (N == 8 && is_foreground(bin, i + s_bot_right)) {
-            c = std::min(c, get_cost<T>(cost, i + s_bot_right, { -1, -1 }));
+            c = std::min(c, cost.template get_cost<-1, -1>(i + s_bot_right));
         }
 
         if (c < limit) {
@@ -198,15 +191,15 @@ void weighted_distance_transform(Image<T>& out, F& bin, M& mask, C& cost, Q& q,
             auto c = std::numeric_limits<T>::max();
 
             if (is_foreground(bin, i + s_left)) {
-                c = std::min(c, get_cost<T>(cost, i + s_left, { 1, 0 }));
+                c = std::min(c, cost.template get_cost<1, 0>(i + s_left));
             }
 
             if (N == 8 && is_foreground(bin, i + s_bot_left)) {
-                c = std::min(c, get_cost<T>(cost, i + s_bot_left, { 1, -1 }));
+                c = std::min(c, cost.template get_cost<1, -1>(i + s_bot_left));
             }
 
             if (is_foreground(bin, i + s_bot)) {
-                c = std::min(c, get_cost<T>(cost, i + s_bot, { 0, -1 }));
+                c = std::min(c, cost.template get_cost<0, -1>(i + s_bot));
             }
 
             if (c < limit) {
@@ -228,23 +221,23 @@ void weighted_distance_transform(Image<T>& out, F& bin, M& mask, C& cost, Q& q,
                 auto c = std::numeric_limits<T>::max();
 
                 if (is_foreground(bin, i + s_right)) {
-                    c = std::min(c, get_cost<T>(cost, i + s_right, { -1, 0 }));
+                    c = std::min(c, cost.template get_cost<-1, 0>(i + s_right));
                 }
 
                 if (is_foreground(bin, i + s_top)) {
-                    c = std::min(c, get_cost<T>(cost, i + s_top, { 0, 1 }));
+                    c = std::min(c, cost.template get_cost<0, 1>(i + s_top));
                 }
 
                 if (N == 8 && is_foreground(bin, i + s_top_right)) {
-                    c = std::min(c, get_cost<T>(cost, i + s_top_right, { -1, 1 }));
+                    c = std::min(c, cost.template get_cost<-1, 1>(i + s_top_right));
                 }
 
                 if (is_foreground(bin, i + s_bot)) {
-                    c = std::min(c, get_cost<T>(cost, i + s_bot, { 0, -1 }));
+                    c = std::min(c, cost.template get_cost<0, -1>(i + s_bot));
                 }
 
                 if (N == 8 && is_foreground(bin, i + s_bot_right)) {
-                    c = std::min(c, get_cost<T>(cost, i + s_bot_right, { -1, -1 }));
+                    c = std::min(c, cost.template get_cost<-1, -1>(i + s_bot_right));
                 }
 
                 if (c < limit) {
@@ -276,35 +269,35 @@ void weighted_distance_transform(Image<T>& out, F& bin, M& mask, C& cost, Q& q,
             auto c = std::numeric_limits<T>::max();
 
             if (is_foreground(bin, i + s_left)) {
-                c = std::min(c, get_cost<T>(cost, i + s_left, { 1, 0 }));
+                c = std::min(c, cost.template get_cost<1, 0>(i + s_left));
             }
 
             if (is_foreground(bin, i + s_right)) {
-                c = std::min(c, get_cost<T>(cost, i + s_right, { -1, 0 }));
+                c = std::min(c, cost.template get_cost<-1, 0>(i + s_right));
             }
 
             if (N == 8 && is_foreground(bin, i + s_top_left)) {
-                c = std::min(c, get_cost<T>(cost, i + s_top_left, { 1, 1 }));
+                c = std::min(c, cost.template get_cost<1, 1>(i + s_top_left));
             }
 
             if (is_foreground(bin, i + s_top)) {
-                c = std::min(c, get_cost<T>(cost, i + s_top, { 0, 1 }));
+                c = std::min(c, cost.template get_cost<0, 1>(i + s_top));
             }
 
             if (N == 8 && is_foreground(bin, i + s_top_right)) {
-                c = std::min(c, get_cost<T>(cost, i + s_top_right, { -1, 1 }));
+                c = std::min(c, cost.template get_cost<-1, 1>(i + s_top_right));
             }
 
             if (N == 8 && is_foreground(bin, i + s_bot_left)) {
-                c = std::min(c, get_cost<T>(cost, i + s_bot_left, { 1, -1 }));
+                c = std::min(c, cost.template get_cost<1, -1>(i + s_bot_left));
             }
 
             if (is_foreground(bin, i + s_bot)) {
-                c = std::min(c, get_cost<T>(cost, i + s_bot, { 0, -1 }));
+                c = std::min(c, cost.template get_cost<0, -1>(i + s_bot));
             }
 
             if (N == 8 && is_foreground(bin, i + s_bot_right)) {
-                c = std::min(c, get_cost<T>(cost, i + s_bot_right, { -1, -1 }));
+                c = std::min(c, cost.template get_cost<-1, -1>(i + s_bot_right));
             }
 
             // if we have a finite projected cost, add this pixel
@@ -321,23 +314,23 @@ void weighted_distance_transform(Image<T>& out, F& bin, M& mask, C& cost, Q& q,
                 auto c = std::numeric_limits<T>::max();
 
                 if (is_foreground(bin, i + s_left)) {
-                    c = std::min(c, get_cost<T>(cost, i + s_left, { 1, 0 }));
+                    c = std::min(c, cost.template get_cost<1, 0>(i + s_left));
                 }
 
                 if (N == 8 && is_foreground(bin, i + s_top_left)) {
-                    c = std::min(c, get_cost<T>(cost, i + s_top_left, { 1, 1 }));
+                    c = std::min(c, cost.template get_cost<1, 1>(i + s_top_left));
                 }
 
                 if (is_foreground(bin, i + s_top)) {
-                    c = std::min(c, get_cost<T>(cost, i + s_top, { 0, 1 }));
+                    c = std::min(c, cost.template get_cost<0, 1>(i + s_top));
                 }
 
                 if (N == 8 && is_foreground(bin, i + s_bot_left)) {
-                    c = std::min(c, get_cost<T>(cost, i + s_bot_left, { 1, -1 }));
+                    c = std::min(c, cost.template get_cost<1, -1>(i + s_bot_left));
                 }
 
                 if (is_foreground(bin, i + s_bot)) {
-                    c = std::min(c, get_cost<T>(cost, i + s_bot, { 0, -1 }));
+                    c = std::min(c, cost.template get_cost<0, -1>(i + s_bot));
                 }
 
                 if (c < limit) {
@@ -358,15 +351,15 @@ void weighted_distance_transform(Image<T>& out, F& bin, M& mask, C& cost, Q& q,
             auto c = std::numeric_limits<T>::max();
 
             if (is_foreground(bin, i + s_right)) {
-                c = std::min(c, get_cost<T>(cost, i + s_right, { -1, 0 }));
+                c = std::min(c, cost.template get_cost<-1, 0>(i + s_right));
             }
 
             if (is_foreground(bin, i + s_top)) {
-                c = std::min(c, get_cost<T>(cost, i + s_top, { 0, 1 }));
+                c = std::min(c, cost.template get_cost<0, 1>(i + s_top));
             }
 
             if (N == 8 && is_foreground(bin, i + s_top_right)) {
-                c = std::min(c, get_cost<T>(cost, i + s_top_right, { -1, 1 }));
+                c = std::min(c, cost.template get_cost<-1, 1>(i + s_top_right));
             }
 
             if (c < limit) {
@@ -393,23 +386,23 @@ void weighted_distance_transform(Image<T>& out, F& bin, M& mask, C& cost, Q& q,
         auto c = std::numeric_limits<T>::max();
 
         if (is_foreground(bin, i + s_left)) {
-            c = std::min(c, get_cost<T>(cost, i + s_left, { 1, 0 }));
+            c = std::min(c, cost.template get_cost<1, 0>(i + s_left));
         }
 
         if (is_foreground(bin, i + s_right)) {
-            c = std::min(c, get_cost<T>(cost, i + s_right, { -1, 0 }));
+            c = std::min(c, cost.template get_cost<-1, 0>(i + s_right));
         }
 
         if (N == 8 && is_foreground(bin, i + s_top_left)) {
-            c = std::min(c, get_cost<T>(cost, i + s_top_left, { 1, 1 }));
+            c = std::min(c, cost.template get_cost<1, 1>(i + s_top_left));
         }
 
         if (is_foreground(bin, i + s_top)) {
-            c = std::min(c, get_cost<T>(cost, i + s_top, { 0, 1 }));
+            c = std::min(c, cost.template get_cost<0, 1>(i + s_top));
         }
 
         if (N == 8 && is_foreground(bin, i + s_top_right)) {
-            c = std::min(c, get_cost<T>(cost, i + s_top_right, { -1, 1 }));
+            c = std::min(c, cost.template get_cost<-1, 1>(i + s_top_right));
         }
 
         if (c < limit) {
@@ -425,15 +418,15 @@ void weighted_distance_transform(Image<T>& out, F& bin, M& mask, C& cost, Q& q,
             auto c = std::numeric_limits<T>::max();
 
             if (is_foreground(bin, i + s_left)) {
-                c = std::min(c, get_cost<T>(cost, i + s_left, { 1, 0 }));
+                c = std::min(c, cost.template get_cost<1, 0>(i + s_left));
             }
 
             if (N == 8 && is_foreground(bin, i + s_top_left)) {
-                c = std::min(c, get_cost<T>(cost, i + s_top_left, { 1, 1 }));
+                c = std::min(c, cost.template get_cost<1, 1>(i + s_top_left));
             }
 
             if (is_foreground(bin, i + s_top)) {
-                c = std::min(c, get_cost<T>(cost, i + s_top, { 0, 1 }));
+                c = std::min(c, cost.template get_cost<0, 1>(i + s_top));
             }
 
             if (c < limit) {
@@ -461,34 +454,34 @@ void weighted_distance_transform(Image<T>& out, F& bin, M& mask, C& cost, Q& q,
         auto const [x, y] = Image<T>::unravel(out.size(), pixel.idx);
 
         if (x > 0) {
-            evaluate(out, q, bin, mask, cost, pixel.idx, s_left, { -1, 0 }, limit);
+            evaluate<-1, 0>(out, q, bin, mask, cost, pixel.idx, s_left, limit);
         }
 
         if (x < out.size().x - 1) {
-            evaluate(out, q, bin, mask, cost, pixel.idx, s_right, { 1, 0 }, limit);
+            evaluate<1, 0>(out, q, bin, mask, cost, pixel.idx, s_right, limit);
         }
 
         if (y > 0) {
             if (N == 8 && x > 0) {
-                evaluate(out, q, bin, mask, cost, pixel.idx, s_top_left, { -1, -1 }, limit);
+                evaluate<-1, -1>(out, q, bin, mask, cost, pixel.idx, s_top_left, limit);
             }
 
-            evaluate(out, q, bin, mask, cost, pixel.idx, s_top, { 0, -1 }, limit);
+            evaluate<0, -1>(out, q, bin, mask, cost, pixel.idx, s_top, limit);
 
             if (N == 8 && x < out.size().x - 1) {
-                evaluate(out, q, bin, mask, cost, pixel.idx, s_top_right, { 1, -1 }, limit);
+                evaluate<1, -1>(out, q, bin, mask, cost, pixel.idx, s_top_right, limit);
             }
         }
 
         if (y < out.size().y - 1) {
             if (N == 8 && x > 0) {
-                evaluate(out, q, bin, mask, cost, pixel.idx, s_bot_left, { -1, 1 }, limit);
+                evaluate<-1, 1>(out, q, bin, mask, cost, pixel.idx, s_bot_left, limit);
             }
 
-            evaluate(out, q, bin, mask, cost, pixel.idx, s_bot, { 0, 1 }, limit);
+            evaluate<0, 1>(out, q, bin, mask, cost, pixel.idx, s_bot, limit);
 
             if (N == 8 && x < out.size().x - 1) {
-                evaluate(out, q, bin, mask, cost, pixel.idx, s_bot_right, { 1, 1 }, limit);
+                evaluate<1, 1>(out, q, bin, mask, cost, pixel.idx, s_bot_right, limit);
             }
         }
     }

--- a/src/contacts/advanced/detector.cpp
+++ b/src/contacts/advanced/detector.cpp
@@ -66,6 +66,36 @@ BlobDetector::BlobDetector(index2_t size, BlobDetectorConfig config)
     alg::gfit::reserve(m_gf_params, 32, size);
 }
 
+class WdtCost {
+public:
+    WdtCost(Image<std::array<f32, 2>> const* m_img_stev_,
+        Image<f32> const* m_img_rdg_) : m_img_stev{m_img_stev_}
+    , m_img_rdg{m_img_rdg_} {}
+
+    template<index_t DX, index_t DY>
+    auto get_cost(index_t i) const
+    {
+        f32 constexpr c_dist = 0.1f;
+        f32 constexpr c_ridge = 9.0f;
+        f32 constexpr c_grad = 1.0f;
+
+        static_assert(DX == -1 || DX == 0 || DX == 1);
+        static_assert(DY == -1 || DY == 0 || DY == 1);
+        // auto const dist = std::hypotf(gsl::narrow<f32>(d.x), gsl::narrow<f32>(d.y));
+        f32 constexpr dist = DX * DY == 0 ? 1 : M_SQRT2;
+
+        auto const [ev1, ev2] = (*m_img_stev)[i];
+        auto const grad = std::max(ev1, 0.0f) + std::max(ev2, 0.0f);
+        auto const ridge = (*m_img_rdg)[i];
+
+        return c_ridge * ridge + c_grad * grad + c_dist * dist;
+    }
+
+private:
+    Image<std::array<f32, 2>> const* m_img_stev;
+    Image<f32> const* m_img_rdg;
+};
+
 auto BlobDetector::process(Image<f32> const& hm) -> std::vector<Blob> const&
 {
     // preprocessing
@@ -193,19 +223,7 @@ auto BlobDetector::process(Image<f32> const& hm) -> std::vector<Blob> const&
     // distance transform
     {
         auto const th_inc = 0.6f;
-
-        auto const wdt_cost = [&](index_t i, index2_t d) -> f32 {
-            f32 const c_dist = 0.1f;
-            f32 const c_ridge = 9.0f;
-            f32 const c_grad = 1.0f;
-
-            auto const [ev1, ev2] = m_img_stev[i];
-            auto const grad = std::max(ev1, 0.0f) + std::max(ev2, 0.0f);
-            auto const ridge = m_img_rdg[i];
-            auto const dist = std::hypotf(gsl::narrow<f32>(d.x), gsl::narrow<f32>(d.y));
-
-            return c_ridge * ridge + c_grad * grad + c_dist * dist;
-        };
+        const WdtCost wdt_cost {&m_img_stev, &m_img_rdg};
 
         auto const wdt_mask = [&](index_t i) -> bool {
             return m_img_pp[i] > 0.0f && m_img_lbl[i] == 0;

--- a/src/contacts/advanced/detector.cpp
+++ b/src/contacts/advanced/detector.cpp
@@ -68,12 +68,12 @@ BlobDetector::BlobDetector(index2_t size, BlobDetectorConfig config)
 
 class WdtCost {
 public:
-    WdtCost(Image<std::array<f32, 2>> const* m_img_stev_,
-        Image<f32> const* m_img_rdg_) : m_img_stev{m_img_stev_}
+    WdtCost(Image<std::array<f32, 2>> const& m_img_stev_,
+        Image<f32> const& m_img_rdg_) : m_img_stev{m_img_stev_}
     , m_img_rdg{m_img_rdg_} {}
 
     template<index_t DX, index_t DY>
-    auto get_cost(index_t i) const
+    [[gnu::always_inline]] [[nodiscard]] f32 get_cost(index_t i) const
     {
         f32 constexpr c_dist = 0.1f;
         f32 constexpr c_ridge = 9.0f;
@@ -84,16 +84,16 @@ public:
         // auto const dist = std::hypotf(gsl::narrow<f32>(d.x), gsl::narrow<f32>(d.y));
         f32 constexpr dist = DX * DY == 0 ? 1 : M_SQRT2;
 
-        auto const [ev1, ev2] = (*m_img_stev)[i];
+        auto const [ev1, ev2] = common::unchecked<std::array<f32, 2>>(m_img_stev.get(), i);
         auto const grad = std::max(ev1, 0.0f) + std::max(ev2, 0.0f);
-        auto const ridge = (*m_img_rdg)[i];
+        auto const ridge = common::unchecked<f32>(m_img_rdg.get(), i);
 
         return c_ridge * ridge + c_grad * grad + c_dist * dist;
     }
 
 private:
-    Image<std::array<f32, 2>> const* m_img_stev;
-    Image<f32> const* m_img_rdg;
+    std::reference_wrapper<const Image<std::array<f32, 2>>> m_img_stev;
+    std::reference_wrapper<const Image<f32>> m_img_rdg;
 };
 
 auto BlobDetector::process(Image<f32> const& hm) -> std::vector<Blob> const&
@@ -223,18 +223,20 @@ auto BlobDetector::process(Image<f32> const& hm) -> std::vector<Blob> const&
     // distance transform
     {
         auto const th_inc = 0.6f;
-        const WdtCost wdt_cost {&m_img_stev, &m_img_rdg};
+        const WdtCost wdt_cost {m_img_stev, m_img_rdg};
 
         auto const wdt_mask = [&](index_t i) -> bool {
-            return m_img_pp[i] > 0.0f && m_img_lbl[i] == 0;
+            return common::unchecked<f32>(m_img_pp, i) > 0.0f && common::unchecked<u16>(m_img_lbl, i) == 0;
         };
 
         auto const wdt_inc_bin = [&](index_t i) -> bool {
-            return m_img_lbl[i] > 0 && m_cscore.at(m_img_lbl[i] - 1) > th_inc;
+            u16 const lbl = common::unchecked<u16>(m_img_lbl, i);
+            return lbl > 0 && common::unchecked<f32>(m_cscore, lbl - 1) > th_inc;
         };
 
         auto const wdt_exc_bin = [&](index_t i) -> bool {
-            return m_img_lbl[i] > 0 && m_cscore.at(m_img_lbl[i] - 1) <= th_inc;
+            u16 const lbl = common::unchecked<u16>(m_img_lbl, i);
+            return lbl && common::unchecked<f32>(m_cscore, lbl - 1) <= th_inc;
         };
 
         alg::weighted_distance_transform<4>(m_img_dm1, wdt_inc_bin, wdt_mask, wdt_cost, m_wdt_queue, 6.0f);


### PR DESCRIPTION
This PR improves the advanced detector algorithm running time by 34% from 3000us to 2400us. This was measured on iptsd-perf using Linux perf.

I ran the profiler on iptsd-perf and found it strange that 25% of the time was spent on std::hypotf. I took a look at the code only to find that function was only called on constants. I tried adding `inline` to `get_cost`, but the compiler still wouldn't inline it. Therefore, I forced the compiler to inline things using template parameters and `constexpr`. This improved the performance by 20%.

`std::reference_wrapper` is used in the class desugared from the lambda by request. It initially caused a small degradation, until I did the following. In the disassembly, I see a lot of calls related to std::vector, so I determined that bounds checks were taking a lot of time. I applied the `common::unchecked` pattern to this lambda, and the nearby ones. This improved the performance by a further 17%.

These measurements were done on `iptsd-perf` on a separate machine. With the actual Surface Pro 7 device, and the actual `iptsd` daemon, it was around 50%+ CPU usage before, and around 45% after. I would have investigated that discrepancy if I had a working `perf`. It's the same 34% in perf, but a 10% in `iptsd`. The actual numbers follow:

<details>
<summary>On-device numbers</summary>

```
# 0 commits
[03:19:06.555] [info] Vendor:       045E
[03:19:06.555] [info] Product:      099F
[03:19:06.555] [info] Buffer Size:  7487
[03:19:06.555] [info] Metadata:
[03:19:06.555] [info] rows=44, columns=64
[03:19:06.555] [info] width=25978, height=17319
[03:19:06.555] [info] transform=[-412.3492,0,25978,0,-402.76746,17319]
[03:19:06.555] [info] unknown=1, [178,182,180,1,178,182,180,1,90,171,100,20,172,177,175,2]
[03:19:14.614] [info] Ran 2010 times
[03:19:14.614] [info] Total: 8042632μs
[03:19:14.614] [info] Mean: 4001.31μs
[03:19:14.614] [info] Standard Deviation: 1399.72μs
[03:19:14.614] [info] Minimum: 181.138μs
[03:19:14.614] [info] Maximum: 7771.524μs
# 1 commit
[03:17:18.905] [info] Vendor:       045E
[03:17:18.905] [info] Product:      099F
[03:17:18.905] [info] Buffer Size:  7487
[03:17:18.905] [info] Metadata:
[03:17:18.905] [info] rows=44, columns=64
[03:17:18.905] [info] width=25978, height=17319
[03:17:18.905] [info] transform=[-412.3492,0,25978,0,-402.76746,17319]
[03:17:18.905] [info] unknown=1, [178,182,180,1,178,182,180,1,90,171,100,20,172,177,175,2]
[03:17:25.786] [info] Ran 2010 times
[03:17:25.786] [info] Total: 6860737μs
[03:17:25.786] [info] Mean: 3413.30μs
[03:17:25.786] [info] Standard Deviation: 1174.28μs
[03:17:25.786] [info] Minimum: 180.452μs
[03:17:25.786] [info] Maximum: 6039.696μs
# commits
[03:16:14.245] [info] Vendor:       045E
[03:16:14.245] [info] Product:      099F
[03:16:14.245] [info] Buffer Size:  7487
[03:16:14.245] [info] Metadata:
[03:16:14.245] [info] rows=44, columns=64
[03:16:14.245] [info] width=25978, height=17319
[03:16:14.245] [info] transform=[-412.3492,0,25978,0,-402.76746,17319]
[03:16:14.245] [info] unknown=1, [178,182,180,1,178,182,180,1,90,171,100,20,172,177,175,2]
[03:16:19.668] [info] Ran 2010 times
[03:16:19.668] [info] Total: 5399899μs
[03:16:19.668] [info] Mean: 2686.52μs
[03:16:19.668] [info] Standard Deviation: 906.13μs
[03:16:19.668] [info] Minimum: 177.923μs
[03:16:19.668] [info] Maximum: 4784.426μs
```
</details>

# Before

```
/home/home/CLionProjects/iptsd/build/src/debug/iptsd-perf ./iptsdump.dat
[08:03:23.027] [info] Vendor:       045E
[08:03:23.027] [info] Product:      099F
[08:03:23.027] [info] Buffer Size:  7487
[08:03:23.027] [info] Metadata:
[08:03:23.027] [info] rows=44, columns=64
[08:03:23.027] [info] width=25978, height=17319
[08:03:23.027] [info] transform=[-412.3492,0,25978,0,-402.76746,17319]
[08:03:23.027] [info] unknown=1, [178,182,180,1,178,182,180,1,90,171,100,20,172,177,175,2]
[08:03:29.048] [info] Ran 2010 times
[08:03:29.048] [info] Total: 6011079μs
[08:03:29.048] [info] Mean: 2990.59μs
[08:03:29.048] [info] Standard Deviation: 1045.43μs
[08:03:29.048] [info] Minimum: 147.510μs
[08:03:29.048] [info] Maximum: 5385.695μs
```

![image](https://user-images.githubusercontent.com/25646384/220932567-e2182518-97d5-4ba3-8be3-1cdad03396b8.png)

# After

```
[22:20:12.187] [info] Vendor:       045E
[22:20:12.187] [info] Product:      099F
[22:20:12.187] [info] Buffer Size:  7487
[22:20:12.187] [info] Metadata:
[22:20:12.187] [info] rows=44, columns=64
[22:20:12.187] [info] width=25978, height=17319
[22:20:12.187] [info] transform=[-412.3492,0,25978,0,-402.76746,17319]
[22:20:12.187] [info] unknown=1, [178,182,180,1,178,182,180,1,90,171,100,20,172,177,175,2]
[22:20:16.228] [info] Ran 2010 times
[22:20:16.228] [info] Total: 4031356μs
[22:20:16.228] [info] Mean: 2005.65μs
[22:20:16.228] [info] Standard Deviation: 674.57μs
[22:20:16.228] [info] Minimum: 144.730μs
[22:20:16.228] [info] Maximum: 3357.086μs
```

![image](https://user-images.githubusercontent.com/25646384/221084140-3017ed53-dffb-4143-be3b-09323a030b6d.png)
