### PR TITLE
Add IPTSD_CONFIG_FILE environment variable

### DIFF
--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -200,10 +200,20 @@ Config::Config(i16 vendor, i16 product, std::optional<const ipts::Metadata> meta
 	this->load_dir(IPTSD_PRESET_DIR, true);
 	this->load_dir("./etc/presets", true);
 
-	if (std::filesystem::exists(IPTSD_CONFIG_FILE))
-		ini_parse(IPTSD_CONFIG_FILE, parse_conf, this);
+	if (const char *config_file_path = std::getenv("IPTSD_CONFIG_FILE")) {
+		// Load configuration file from custom location
+		// Mainly for developers to debug their work
+		// without touching their known working main system configuration
+		if (!std::filesystem::exists(config_file_path))
+			throw std::runtime_error("IPTSD_CONFIG_FILE not found");
+		if (ini_parse(config_file_path, parse_conf, this))
+			throw std::runtime_error("IPTSD_CONFIG_FILE is corrupt");
+	} else {
+		if (std::filesystem::exists(IPTSD_CONFIG_FILE))
+			ini_parse(IPTSD_CONFIG_FILE, parse_conf, this);
 
-	this->load_dir(IPTSD_CONFIG_DIR, false);
+		this->load_dir(IPTSD_CONFIG_DIR, false);
+	}
 }
 
 contacts::Config Config::contacts() const


### PR DESCRIPTION
Add an environment variable named `IPTSD_CONFIG_FILE` to load a configuration file from a custom location. This will mainly be used during development.

Currently the configuration is loaded from somewhere in `/etc/**` and `/usr/**`. Those directories are normally only writable by root. I have a hack where I did `sudo ln -s /home/home/Downloads/iptsd.conf /etc/iptsd.conf`. The situation is even worse for those developing on-device. With this PR, I hope to remove this hack.

This environment variable could also be used for automated testing.