### PR TITLE
Preview: Optimize the advanced detector further by 50%

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -3,7 +3,7 @@ project('iptsd', 'cpp', 'c',
         license: 'GPL-2.0-or-later',
         meson_version: '>=0.56.0',
         default_options: [
-          'cpp_std=c++17',
+          'cpp_std=c++20',
           'warning_level=3',
           'werror=true',
           'sysconfdir=/etc',

--- a/src/contacts/advanced/algorithm/convolution.hpp
+++ b/src/contacts/advanced/algorithm/convolution.hpp
@@ -59,7 +59,7 @@ inline constexpr Kernel<T, 3, 3> sobel3_xy {
 
 
 template<class T, index_t Nx, index_t Ny>
-auto gaussian(T sigma) -> Kernel<T, Nx, Ny>
+constexpr auto gaussian(T sigma) -> Kernel<T, Nx, Ny>
 {
     static_assert(Nx % 2 == 1);
     static_assert(Ny % 2 == 1);

--- a/src/contacts/advanced/algorithm/distance_transform.hpp
+++ b/src/contacts/advanced/algorithm/distance_transform.hpp
@@ -2,6 +2,7 @@
 
 #include <common/types.hpp>
 #include <container/image.hpp>
+#include "../detector.hpp"
 
 #include <queue>
 #include <numeric>
@@ -10,80 +11,66 @@ using namespace iptsd::container;
 
 
 namespace iptsd::contacts::advanced::alg {
-namespace wdt {
 
-template<typename T>
-struct QItem {
-    index_t idx;
-    T cost;
+using iptsd::contacts::advanced::BlobDetector;
+
+template<index_t DX, index_t DY>
+[[gnu::always_inline]] [[nodiscard]] inline f32 get_cost(BlobDetector *d, index_t i)
+{
+    f32 constexpr c_dist = 0.1f;
+    f32 constexpr c_ridge = 9.0f;
+    f32 constexpr c_grad = 1.0f;
+
+    static_assert(DX == -1 || DX == 0 || DX == 1);
+    static_assert(DY == -1 || DY == 0 || DY == 1);
+    // auto const dist = std::hypotf(gsl::narrow<f32>(d.x), gsl::narrow<f32>(d.y));
+    f32 constexpr dist = DX * DY == 0 ? 1 : M_SQRT2;
+
+    auto const [ev1, ev2] = common::unchecked<std::array<f32, 2>>(d->m_img_stev, i);
+    auto const grad = std::max(ev1, 0.0f) + std::max(ev2, 0.0f);
+    auto const ridge = common::unchecked<f32>(d->m_img_rdg, i);
+
+    return c_ridge * ridge + c_grad * grad + c_dist * dist;
+}
+
+auto constexpr th_inc = 0.6f;
+
+constexpr bool mask(BlobDetector *d, index_t i) {
+    return common::unchecked<f32>(d->m_img_pp, i) > 0.0f && common::unchecked<u16>(d->m_img_lbl, i) == 0;
 };
 
-template<typename T>
-auto operator== (struct QItem<T> const& a, struct QItem<T> const& b) noexcept -> bool
-{
-    return a.cost == b.cost;
-}
+constexpr bool wdt_inc_bin(BlobDetector *d, index_t i) {
+    u16 const lbl = common::unchecked<u16>(d->m_img_lbl, i);
+    return lbl > 0 && common::unchecked<f32>(d->m_cscore, lbl - 1) > th_inc;
+};
 
-template<typename T>
-auto operator!= (struct QItem<T> const& a, struct QItem<T> const& b) noexcept -> bool
-{
-    return a.cost != b.cost;
-}
+constexpr bool wdt_exc_bin(BlobDetector *d, index_t i) {
+    u16 const lbl = common::unchecked<u16>(d->m_img_lbl, i);
+    return lbl && common::unchecked<f32>(d->m_cscore, lbl - 1) <= th_inc;
+};
 
-template<typename T>
-auto operator<= (struct QItem<T> const& a, struct QItem<T> const& b) noexcept -> bool
-{
-    return a.cost <= b.cost;
-}
+#define is_masked(i) !mask(d, i)
+#define is_foreground(i) (INC_OR_EXC ? wdt_inc_bin(d, i) : wdt_exc_bin(d, i))
+#define is_compute(i) (!is_foreground(i) && !is_masked(i))
 
-template<typename T>
-auto operator>= (struct QItem<T> const& a, struct QItem<T> const& b) noexcept -> bool
-{
-    return a.cost >= b.cost;
-}
-
-template<typename T>
-auto operator< (struct QItem<T> const& a, struct QItem<T> const& b) noexcept -> bool
-{
-    return a.cost < b.cost;
-}
-
-template<typename T>
-auto operator> (struct QItem<T> const& a, struct QItem<T> const& b) noexcept -> bool
-{
-    return a.cost > b.cost;
-}
-
-
-namespace impl {
-
-#define is_masked(mask, i) !mask(i)
-#define is_foreground(bin, i) bin(i)
-#define is_compute(bin, mask, i) (!is_foreground(bin, i) && !is_masked(mask, i))
-
-template<index_t DX, index_t DY, typename T, typename Q, typename B, typename M, typename C>
-inline void evaluate(Image<T>& out, Q& queue, B& bin, M& mask, C& cost, index_t i,
+template<index_t DX, index_t DY, bool INC_OR_EXC, typename T, typename Q>
+inline void evaluate(BlobDetector *d, Image<T>& out, Q& queue, index_t i,
                      index_t stride, T limit)
 {
-    if (!is_compute(bin, mask, i + stride))
+    if (!is_compute(i + stride))
         return;
 
-    auto const c = out[i] + cost.template get_cost<DX, DY>(i);
+    auto const c = out[i] + get_cost<DX, DY>(d, i);
 
     if (c < out[i + stride] && c < limit) {
         queue.push({ i + stride, c });
     }
 }
 
-} /* namespace impl */
-} /* namespace wdt */
-
-template<int N=8, typename T, typename F, typename M, typename C, typename Q>
-[[gnu::always_inline]] inline void weighted_distance_transform_1(Image<T>& out, F& bin, M& mask, C& cost, Q& q,
-                                 T limit=std::numeric_limits<T>::max())
+template<int N=8, bool INC_OR_EXC, typename Q, typename T>
+[[gnu::always_inline]] inline void weighted_distance_transform_1(Image<T>& out, BlobDetector *d, Q& q,
+T limit=std::numeric_limits<T>::max())
 {
-    using wdt::impl::evaluate;
-
     static_assert(N == 4 || N == 8);
 
     // strides
@@ -100,22 +87,22 @@ template<int N=8, typename T, typename F, typename M, typename C, typename Q>
     index_t i = 0;
 
     // x = 0, y = 0
-    if (!is_foreground(bin, i)) {
+    if (!is_foreground(i)) {
         out[i] = std::numeric_limits<T>::max();
 
-        if (!is_masked(mask, i)) {
+        if (!is_masked(i)) {
             auto c = std::numeric_limits<T>::max();
 
-            if (is_foreground(bin, i + s_right)) {
-                c = std::min(c, cost.template get_cost<-1, 0>(i + s_right));
+            if (is_foreground(i + s_right)) {
+                c = std::min(c, get_cost<-1, 0>(d, i + s_right));
             }
 
-            if (is_foreground(bin, i + s_bot)) {
-                c = std::min(c, cost.template get_cost<0, -1>(i + s_bot));
+            if (is_foreground(i + s_bot)) {
+                c = std::min(c, get_cost<0, -1>(d, i + s_bot));
             }
 
-            if (N == 8 && is_foreground(bin, i + s_bot_right)) {
-                c = std::min(c, cost.template get_cost<-1, -1>(i + s_bot_right));
+            if (N == 8 && is_foreground(i + s_bot_right)) {
+                c = std::min(c, get_cost<-1, -1>(d, i + s_bot_right));
             }
 
             if (c < limit) {
@@ -129,36 +116,36 @@ template<int N=8, typename T, typename F, typename M, typename C, typename Q>
 
     // 0 < x < n - 1, y = 0
     for (; i < out.size().x - 1; ++i) {
-        if (is_foreground(bin, i)) {
+        if (is_foreground(i)) {
             out[i] = static_cast<T>(0);
             continue;
         }
 
         out[i] = std::numeric_limits<T>::max();
 
-        if (is_masked(mask, i))
+        if (is_masked(i))
             continue;
 
         auto c = std::numeric_limits<T>::max();
 
-        if (is_foreground(bin, i + s_left)) {
-            c = std::min(c, cost.template get_cost<1, 0>(i + s_left));
+        if (is_foreground(i + s_left)) {
+            c = std::min(c, get_cost<1, 0>(d, i + s_left));
         }
 
-        if (is_foreground(bin, i + s_right)) {
-            c = std::min(c, cost.template get_cost<-1, 0>(i + s_right));
+        if (is_foreground(i + s_right)) {
+            c = std::min(c, get_cost<-1, 0>(d, i + s_right));
         }
 
-        if (N == 8 && is_foreground(bin, i + s_bot_left)) {
-            c = std::min(c, cost.template get_cost<1, -1>(i + s_bot_left));
+        if (N == 8 && is_foreground(i + s_bot_left)) {
+            c = std::min(c, get_cost<1, -1>(d, i + s_bot_left));
         }
 
-        if (is_foreground(bin, i + s_bot)) {
-            c = std::min(c, cost.template get_cost<0, -1>(i + s_bot));
+        if (is_foreground(i + s_bot)) {
+            c = std::min(c, get_cost<0, -1>(d, i + s_bot));
         }
 
-        if (N == 8 && is_foreground(bin, i + s_bot_right)) {
-            c = std::min(c, cost.template get_cost<-1, -1>(i + s_bot_right));
+        if (N == 8 && is_foreground(i + s_bot_right)) {
+            c = std::min(c, get_cost<-1, -1>(d, i + s_bot_right));
         }
 
         if (c < limit) {
@@ -167,22 +154,22 @@ template<int N=8, typename T, typename F, typename M, typename C, typename Q>
     }
 
     // x = n - 1, y = 0
-    if (!is_foreground(bin, i)) {
+    if (!is_foreground(i)) {
         out[i] = std::numeric_limits<T>::max();
 
-        if (!is_masked(mask, i)) {
+        if (!is_masked(i)) {
             auto c = std::numeric_limits<T>::max();
 
-            if (is_foreground(bin, i + s_left)) {
-                c = std::min(c, cost.template get_cost<1, 0>(i + s_left));
+            if (is_foreground(i + s_left)) {
+                c = std::min(c, get_cost<1, 0>(d, i + s_left));
             }
 
-            if (N == 8 && is_foreground(bin, i + s_bot_left)) {
-                c = std::min(c, cost.template get_cost<1, -1>(i + s_bot_left));
+            if (N == 8 && is_foreground(i + s_bot_left)) {
+                c = std::min(c, get_cost<1, -1>(d, i + s_bot_left));
             }
 
-            if (is_foreground(bin, i + s_bot)) {
-                c = std::min(c, cost.template get_cost<0, -1>(i + s_bot));
+            if (is_foreground(i + s_bot)) {
+                c = std::min(c, get_cost<0, -1>(d, i + s_bot));
             }
 
             if (c < limit) {
@@ -197,30 +184,30 @@ template<int N=8, typename T, typename F, typename M, typename C, typename Q>
     // 0 < y < n - 1
     while (i < out.size().x * (out.size().y - 1)) {
         // x = 0
-        if (!is_foreground(bin, i)) {
+        if (!is_foreground(i)) {
             out[i] = std::numeric_limits<T>::max();
 
-            if (!is_masked(mask, i)) {
+            if (!is_masked(i)) {
                 auto c = std::numeric_limits<T>::max();
 
-                if (is_foreground(bin, i + s_right)) {
-                    c = std::min(c, cost.template get_cost<-1, 0>(i + s_right));
+                if (is_foreground(i + s_right)) {
+                    c = std::min(c, get_cost<-1, 0>(d, i + s_right));
                 }
 
-                if (is_foreground(bin, i + s_top)) {
-                    c = std::min(c, cost.template get_cost<0, 1>(i + s_top));
+                if (is_foreground(i + s_top)) {
+                    c = std::min(c, get_cost<0, 1>(d, i + s_top));
                 }
 
-                if (N == 8 && is_foreground(bin, i + s_top_right)) {
-                    c = std::min(c, cost.template get_cost<-1, 1>(i + s_top_right));
+                if (N == 8 && is_foreground(i + s_top_right)) {
+                    c = std::min(c, get_cost<-1, 1>(d, i + s_top_right));
                 }
 
-                if (is_foreground(bin, i + s_bot)) {
-                    c = std::min(c, cost.template get_cost<0, -1>(i + s_bot));
+                if (is_foreground(i + s_bot)) {
+                    c = std::min(c, get_cost<0, -1>(d, i + s_bot));
                 }
 
-                if (N == 8 && is_foreground(bin, i + s_bot_right)) {
-                    c = std::min(c, cost.template get_cost<-1, -1>(i + s_bot_right));
+                if (N == 8 && is_foreground(i + s_bot_right)) {
+                    c = std::min(c, get_cost<-1, -1>(d, i + s_bot_right));
                 }
 
                 if (c < limit) {
@@ -236,7 +223,7 @@ template<int N=8, typename T, typename F, typename M, typename C, typename Q>
         auto const limit = i + out.size().x - 2;
         for (; i < limit; ++i) {
             // if this is a foreground pixel, set it to zero and skip the rest
-            if (is_foreground(bin, i)) {
+            if (is_foreground(i)) {
                 out[i] = static_cast<T>(0);
                 continue;
             }
@@ -245,42 +232,42 @@ template<int N=8, typename T, typename F, typename M, typename C, typename Q>
             out[i] = std::numeric_limits<T>::max();
 
             // don't evaluate pixels that are excluded by mask
-            if (is_masked(mask, i))
+            if (is_masked(i))
                 continue;
 
             // compute minimum cost to any neighboring foreground pixel, if available
             auto c = std::numeric_limits<T>::max();
 
-            if (is_foreground(bin, i + s_left)) {
-                c = std::min(c, cost.template get_cost<1, 0>(i + s_left));
+            if (is_foreground(i + s_left)) {
+                c = std::min(c, get_cost<1, 0>(d, i + s_left));
             }
 
-            if (is_foreground(bin, i + s_right)) {
-                c = std::min(c, cost.template get_cost<-1, 0>(i + s_right));
+            if (is_foreground(i + s_right)) {
+                c = std::min(c, get_cost<-1, 0>(d, i + s_right));
             }
 
-            if (N == 8 && is_foreground(bin, i + s_top_left)) {
-                c = std::min(c, cost.template get_cost<1, 1>(i + s_top_left));
+            if (N == 8 && is_foreground(i + s_top_left)) {
+                c = std::min(c, get_cost<1, 1>(d, i + s_top_left));
             }
 
-            if (is_foreground(bin, i + s_top)) {
-                c = std::min(c, cost.template get_cost<0, 1>(i + s_top));
+            if (is_foreground(i + s_top)) {
+                c = std::min(c, get_cost<0, 1>(d, i + s_top));
             }
 
-            if (N == 8 && is_foreground(bin, i + s_top_right)) {
-                c = std::min(c, cost.template get_cost<-1, 1>(i + s_top_right));
+            if (N == 8 && is_foreground(i + s_top_right)) {
+                c = std::min(c, get_cost<-1, 1>(d, i + s_top_right));
             }
 
-            if (N == 8 && is_foreground(bin, i + s_bot_left)) {
-                c = std::min(c, cost.template get_cost<1, -1>(i + s_bot_left));
+            if (N == 8 && is_foreground(i + s_bot_left)) {
+                c = std::min(c, get_cost<1, -1>(d, i + s_bot_left));
             }
 
-            if (is_foreground(bin, i + s_bot)) {
-                c = std::min(c, cost.template get_cost<0, -1>(i + s_bot));
+            if (is_foreground(i + s_bot)) {
+                c = std::min(c, get_cost<0, -1>(d, i + s_bot));
             }
 
-            if (N == 8 && is_foreground(bin, i + s_bot_right)) {
-                c = std::min(c, cost.template get_cost<-1, -1>(i + s_bot_right));
+            if (N == 8 && is_foreground(i + s_bot_right)) {
+                c = std::min(c, get_cost<-1, -1>(d, i + s_bot_right));
             }
 
             // if we have a finite projected cost, add this pixel
@@ -290,30 +277,30 @@ template<int N=8, typename T, typename F, typename M, typename C, typename Q>
         }
 
         // x = n - 1
-        if (!is_foreground(bin, i)) {
+        if (!is_foreground(i)) {
             out[i] = std::numeric_limits<T>::max();
 
-            if (!is_masked(mask, i)) {
+            if (!is_masked(i)) {
                 auto c = std::numeric_limits<T>::max();
 
-                if (is_foreground(bin, i + s_left)) {
-                    c = std::min(c, cost.template get_cost<1, 0>(i + s_left));
+                if (is_foreground(i + s_left)) {
+                    c = std::min(c, get_cost<1, 0>(d, i + s_left));
                 }
 
-                if (N == 8 && is_foreground(bin, i + s_top_left)) {
-                    c = std::min(c, cost.template get_cost<1, 1>(i + s_top_left));
+                if (N == 8 && is_foreground(i + s_top_left)) {
+                    c = std::min(c, get_cost<1, 1>(d, i + s_top_left));
                 }
 
-                if (is_foreground(bin, i + s_top)) {
-                    c = std::min(c, cost.template get_cost<0, 1>(i + s_top));
+                if (is_foreground(i + s_top)) {
+                    c = std::min(c, get_cost<0, 1>(d, i + s_top));
                 }
 
-                if (N == 8 && is_foreground(bin, i + s_bot_left)) {
-                    c = std::min(c, cost.template get_cost<1, -1>(i + s_bot_left));
+                if (N == 8 && is_foreground(i + s_bot_left)) {
+                    c = std::min(c, get_cost<1, -1>(d, i + s_bot_left));
                 }
 
-                if (is_foreground(bin, i + s_bot)) {
-                    c = std::min(c, cost.template get_cost<0, -1>(i + s_bot));
+                if (is_foreground(i + s_bot)) {
+                    c = std::min(c, get_cost<0, -1>(d, i + s_bot));
                 }
 
                 if (c < limit) {
@@ -327,22 +314,22 @@ template<int N=8, typename T, typename F, typename M, typename C, typename Q>
     }
 
     // x = 0, y = n - 1
-    if (!is_foreground(bin, i)) {
+    if (!is_foreground(i)) {
         out[i] = std::numeric_limits<T>::max();
 
-        if (!is_masked(mask, i)) {
+        if (!is_masked(i)) {
             auto c = std::numeric_limits<T>::max();
 
-            if (is_foreground(bin, i + s_right)) {
-                c = std::min(c, cost.template get_cost<-1, 0>(i + s_right));
+            if (is_foreground(i + s_right)) {
+                c = std::min(c, get_cost<-1, 0>(d, i + s_right));
             }
 
-            if (is_foreground(bin, i + s_top)) {
-                c = std::min(c, cost.template get_cost<0, 1>(i + s_top));
+            if (is_foreground(i + s_top)) {
+                c = std::min(c, get_cost<0, 1>(d, i + s_top));
             }
 
-            if (N == 8 && is_foreground(bin, i + s_top_right)) {
-                c = std::min(c, cost.template get_cost<-1, 1>(i + s_top_right));
+            if (N == 8 && is_foreground(i + s_top_right)) {
+                c = std::min(c, get_cost<-1, 1>(d, i + s_top_right));
             }
 
             if (c < limit) {
@@ -356,36 +343,36 @@ template<int N=8, typename T, typename F, typename M, typename C, typename Q>
 
     // 0 < x < n - 1, y = n - 1
     for (; i < out.size().span() - 1; ++i) {
-        if (is_foreground(bin, i)) {
+        if (is_foreground(i)) {
             out[i] = static_cast<T>(0);
             continue;
         }
 
         out[i] = std::numeric_limits<T>::max();
 
-        if (is_masked(mask, i))
+        if (is_masked(i))
             continue;
 
         auto c = std::numeric_limits<T>::max();
 
-        if (is_foreground(bin, i + s_left)) {
-            c = std::min(c, cost.template get_cost<1, 0>(i + s_left));
+        if (is_foreground(i + s_left)) {
+            c = std::min(c, get_cost<1, 0>(d, i + s_left));
         }
 
-        if (is_foreground(bin, i + s_right)) {
-            c = std::min(c, cost.template get_cost<-1, 0>(i + s_right));
+        if (is_foreground(i + s_right)) {
+            c = std::min(c, get_cost<-1, 0>(d, i + s_right));
         }
 
-        if (N == 8 && is_foreground(bin, i + s_top_left)) {
-            c = std::min(c, cost.template get_cost<1, 1>(i + s_top_left));
+        if (N == 8 && is_foreground(i + s_top_left)) {
+            c = std::min(c, get_cost<1, 1>(d, i + s_top_left));
         }
 
-        if (is_foreground(bin, i + s_top)) {
-            c = std::min(c, cost.template get_cost<0, 1>(i + s_top));
+        if (is_foreground(i + s_top)) {
+            c = std::min(c, get_cost<0, 1>(d, i + s_top));
         }
 
-        if (N == 8 && is_foreground(bin, i + s_top_right)) {
-            c = std::min(c, cost.template get_cost<-1, 1>(i + s_top_right));
+        if (N == 8 && is_foreground(i + s_top_right)) {
+            c = std::min(c, get_cost<-1, 1>(d, i + s_top_right));
         }
 
         if (c < limit) {
@@ -394,22 +381,22 @@ template<int N=8, typename T, typename F, typename M, typename C, typename Q>
     }
 
     // x = n - 1, y = n - 1
-    if (!is_foreground(bin, i)) {
+    if (!is_foreground(i)) {
         out[i] = std::numeric_limits<T>::max();
 
-        if (!is_masked(mask, i)) {
+        if (!is_masked(i)) {
             auto c = std::numeric_limits<T>::max();
 
-            if (is_foreground(bin, i + s_left)) {
-                c = std::min(c, cost.template get_cost<1, 0>(i + s_left));
+            if (is_foreground(i + s_left)) {
+                c = std::min(c, get_cost<1, 0>(d, i + s_left));
             }
 
-            if (N == 8 && is_foreground(bin, i + s_top_left)) {
-                c = std::min(c, cost.template get_cost<1, 1>(i + s_top_left));
+            if (N == 8 && is_foreground(i + s_top_left)) {
+                c = std::min(c, get_cost<1, 1>(d, i + s_top_left));
             }
 
-            if (is_foreground(bin, i + s_top)) {
-                c = std::min(c, cost.template get_cost<0, 1>(i + s_top));
+            if (is_foreground(i + s_top)) {
+                c = std::min(c, get_cost<0, 1>(d, i + s_top));
             }
 
             if (c < limit) {
@@ -421,12 +408,10 @@ template<int N=8, typename T, typename F, typename M, typename C, typename Q>
     }
 }
 
-template<int N=8, typename T, typename F, typename M, typename C, typename Q>
-[[gnu::always_inline]] inline void weighted_distance_transform_2(Image<T>& out, F& bin, M& mask, C& cost, Q& q,
-                                 T limit=std::numeric_limits<T>::max())
+template<int N=8, bool INC_OR_EXC, typename Q, typename T>
+[[gnu::always_inline]] inline void weighted_distance_transform_2(Image<T>& out, BlobDetector *d, Q& q,
+T limit=std::numeric_limits<T>::max())
 {
-    using wdt::impl::evaluate;
-
     static_assert(N == 4 || N == 8);
 
     // strides
@@ -456,45 +441,45 @@ template<int N=8, typename T, typename F, typename M, typename C, typename Q>
         auto const [x, y] = Image<T>::unravel(out.size(), pixel.idx);
 
         if (x > 0) {
-            evaluate<-1, 0>(out, q, bin, mask, cost, pixel.idx, s_left, limit);
+            evaluate<-1, 0, INC_OR_EXC>(d, out, q, pixel.idx, s_left, limit);
         }
 
         if (x < out.size().x - 1) {
-            evaluate<1, 0>(out, q, bin, mask, cost, pixel.idx, s_right, limit);
+            evaluate<1, 0, INC_OR_EXC>(d, out, q, pixel.idx, s_right, limit);
         }
 
         if (y > 0) {
             if (N == 8 && x > 0) {
-                evaluate<-1, -1>(out, q, bin, mask, cost, pixel.idx, s_top_left, limit);
+                evaluate<-1, -1, INC_OR_EXC>(d, out, q, pixel.idx, s_top_left, limit);
             }
 
-            evaluate<0, -1>(out, q, bin, mask, cost, pixel.idx, s_top, limit);
+            evaluate<0, -1, INC_OR_EXC>(d, out, q, pixel.idx, s_top, limit);
 
             if (N == 8 && x < out.size().x - 1) {
-                evaluate<1, -1>(out, q, bin, mask, cost, pixel.idx, s_top_right, limit);
+                evaluate<1, -1, INC_OR_EXC>(d, out, q, pixel.idx, s_top_right, limit);
             }
         }
 
         if (y < out.size().y - 1) {
             if (N == 8 && x > 0) {
-                evaluate<-1, 1>(out, q, bin, mask, cost, pixel.idx, s_bot_left, limit);
+                evaluate<-1, 1, INC_OR_EXC>(d, out, q, pixel.idx, s_bot_left, limit);
             }
 
-            evaluate<0, 1>(out, q, bin, mask, cost, pixel.idx, s_bot, limit);
+            evaluate<0, 1, INC_OR_EXC>(d, out, q, pixel.idx, s_bot, limit);
 
             if (N == 8 && x < out.size().x - 1) {
-                evaluate<1, 1>(out, q, bin, mask, cost, pixel.idx, s_bot_right, limit);
+                evaluate<1, 1, INC_OR_EXC>(d, out, q, pixel.idx, s_bot_right, limit);
             }
         }
     }
 }
 
-template<int N=8, typename T, typename F, typename M, typename C, typename Q>
-[[gnu::always_inline]] inline void weighted_distance_transform(Image<T>& out, F& bin, M& mask, C& cost, Q& q,
+template<int N=8, bool INC_OR_EXC, typename Q, typename T>
+[[gnu::always_inline]] inline void weighted_distance_transform(Image<T>& out, BlobDetector *d, Q& q,
                                  T limit=std::numeric_limits<T>::max())
 {
-    weighted_distance_transform_1<N>(out, bin, mask, cost, q, limit);
-    weighted_distance_transform_2<N>(out, bin, mask, cost, q, limit);
+    weighted_distance_transform_1<N, INC_OR_EXC>(out, d, q, limit);
+    weighted_distance_transform_2<N, INC_OR_EXC>(out, d, q, limit);
 }
 
 } /* namespace iptsd::contacts::advanced::alg */

--- a/src/contacts/advanced/algorithm/gaussian_fitting.hpp
+++ b/src/contacts/advanced/algorithm/gaussian_fitting.hpp
@@ -15,6 +15,7 @@
 #include <spdlog/spdlog.h>
 
 #include <array>
+#include "../arrayvec.hpp"
 
 using namespace iptsd::container;
 using namespace iptsd::math;
@@ -160,7 +161,7 @@ bool extract_params(Vec6<T> const& chi, T& scale, Vec2<T>& mean, Mat2s<T>& prec,
 
 
 template<class T>
-inline void update_weight_maps(std::vector<Parameters<T>>& params, Image<T>& total)
+inline void update_weight_maps(ArrayVec<Parameters<T>, 32>& params, Image<T>& total)
 {
     auto const scale = Vec2<T> {
         static_cast<T>(2) * range<T>.x / static_cast<T>(total.size().x),
@@ -222,7 +223,7 @@ inline void update_weight_maps(std::vector<Parameters<T>>& params, Image<T>& tot
 // TODO: vector as parameter container is not good... drops image memory when resized
 
 template<class T>
-void reserve(std::vector<Parameters<T>>& params, std::size_t n, index2_t size)
+void reserve(ArrayVec<Parameters<T>, 32>& params, std::size_t n, index2_t size)
 {
     if (n > params.size()) {
         params.resize(n, Parameters<T> {
@@ -241,7 +242,7 @@ void reserve(std::vector<Parameters<T>>& params, std::size_t n, index2_t size)
 }
 
 template<class T, class S>
-void fit(std::vector<Parameters<S>>& params, Image<T> const& data,
+void fit(ArrayVec<Parameters<S>, 32>& params, Image<T> const& data,
          Image<S>& tmp, unsigned int n_iter, S eps=math::num<S>::eps)
 {
     auto const scale = Vec2<S> {

--- a/src/contacts/advanced/arrayvec.hpp
+++ b/src/contacts/advanced/arrayvec.hpp
@@ -1,0 +1,57 @@
+#pragma once
+#include <stdexcept>
+
+template <typename T, size_t SIZE>
+class ArrayVec {
+    T impl[SIZE];
+    size_t len{};
+
+// Not bothering to destroy objects when removing
+public:
+    using value_type = T;
+
+    T* data() {
+        return impl;
+    }
+    void push_back(const T& val) {
+        impl[len++] = val;
+    }
+    void push_back(T&& val) {
+        impl[len++] = val;
+    }
+    T* begin() {
+        return impl;
+    }
+    T* end() {
+        return impl + len;
+    }
+    T& at(size_t i) {
+        return impl[i];
+    }
+    T& operator[](size_t i) {
+        return impl[i];
+    }
+    void clear() {
+        len = 0;
+    }
+    void reserve(size_t n) {
+        if (n > SIZE) throw std::runtime_error("arrayvec reserve");
+    }
+    size_t size() {
+        return len;
+    }
+    bool empty() {
+        return !len;
+    }
+    void assign(size_t count, const T& x) {
+        reserve(count);
+        for (size_t i = 0; i < count; ++i) {
+            impl[i] = x;
+        }
+    }
+    void resize(size_t count, const T& x) {
+        for (; len < count; ++len) {
+            impl[len] = x;
+        }
+    }
+};

--- a/src/contacts/advanced/detector.cpp
+++ b/src/contacts/advanced/detector.cpp
@@ -58,11 +58,6 @@ BlobDetector::BlobDetector(index2_t size, BlobDetectorConfig config)
     , m_gf_window{11, 11}
     , m_touchpoints{}
 {
-    std::less<alg::wdt::QItem<f32>> op {};
-    std::vector<alg::wdt::QItem<f32>> buf {512};
-
-    m_wdt_queue = std::priority_queue { op, buf };
-
     alg::gfit::reserve(m_gf_params, 32, size);
 }
 

--- a/src/contacts/advanced/detector.cpp
+++ b/src/contacts/advanced/detector.cpp
@@ -190,8 +190,8 @@ auto BlobDetector::process(Image<f32> const& hm) -> std::vector<Blob> const&
     // distance transform
     {
 
-        alg::weighted_distance_transform<4, true>(m_img_dm1, this, m_wdt_queue, 6.0f);
-        alg::weighted_distance_transform<4, false>(m_img_dm2, this, m_wdt_queue, 6.0f);
+        alg::weighted_distance_transform<4, true>(this);
+        alg::weighted_distance_transform<4, false>(this);
     }
 
     // filter

--- a/src/contacts/advanced/detector.hpp
+++ b/src/contacts/advanced/detector.hpp
@@ -57,6 +57,10 @@ public:
         return {ind[delay_pop], std::bit_cast<f32>(cost[delay_pop])};
     }
 
+    size_t size() {
+        return length;
+    }
+
     void push(alg::wdt::QItem<f32> item) {
         if (length == QUEUE_MAX) {
             throw std::runtime_error("MyQueue overflow");
@@ -229,6 +233,8 @@ public:
     Image<f64> m_img_gftmp;
 
     MyQueue m_wdt_queue;
+    ArrayVec<alg::wdt::QItem<f32>, 1024> m_wdt_queue_young_gen;
+    ArrayVec<alg::wdt::QItem<f32>, 1024> m_wdt_queue_eden_gen;
     ArrayVec<alg::gfit::Parameters<f64>, 32> m_gf_params;
 
     ArrayVec<index_t, 32> m_maximas;

--- a/src/contacts/advanced/detector.hpp
+++ b/src/contacts/advanced/detector.hpp
@@ -14,6 +14,7 @@
 #include <math/mat2.hpp>
 
 #include <array>
+#include <bit>
 #include <vector>
 #include <queue>
 
@@ -30,6 +31,166 @@ struct ComponentStats {
     u32 maximas;
 };
 
+class MyQueue {
+public:
+    #define QUEUE_MAX 1024
+    //alg::wdt::QItem<f32> data[QUEUE_MAX];
+    index_t ind[QUEUE_MAX];
+    i32 cost[QUEUE_MAX];
+    size_t length{};
+    // 0=normal heap, 1=left node is real root, 2=right node is real root
+    size_t delay_pop{};
+
+    alg::wdt::QItem<f32> top() {
+        // IEEE754 floats are bit compatible with being compared as integers
+        // We will just assume that there is nothing special like NaN or Inf
+        return {ind[delay_pop], std::bit_cast<f32>(cost[delay_pop])};
+    }
+
+    void push(alg::wdt::QItem<f32> item) {
+        if (length == QUEUE_MAX) {
+            throw std::runtime_error("MyQueue overflow");
+        }
+        i32 item_cost = std::bit_cast<i32>(item.cost);
+        index_t item_ind = item.idx;
+        if (delay_pop) {
+            delay_pop = 0;
+            downheap(item_cost, item_ind);
+            ++length;
+            return;
+        }
+        size_t idx{length++};
+        while (idx) {
+            size_t next{(idx - 1) / 2};
+            i32 parent = cost[next];
+            if (parent < item_cost) {
+                cost[idx] = parent;
+                ind[idx] = ind[next];
+            } else break;
+            idx = next;
+        }
+        ind[idx] = item_ind;
+        cost[idx] = item_cost;
+    }
+
+    [[nodiscard]] bool empty() const {
+        return !length;
+    }
+
+    void pop() {
+        size_t len = length--;
+        if (delay_pop) {
+            downheap(cost[len], ind[len]);
+        }
+        if (!len) {
+            delay_pop = 0;
+            return;
+        }
+        delay_pop = 1;
+        if (len == 1) return;
+        if (cost[2] > cost[1])
+            delay_pop = 2;
+    }
+
+    void downheap(i32 item_cost, index_t item_ind) {
+        size_t len = length + 1;
+        size_t idx{0};
+        for (;;) {
+            size_t left_idx = 2 * idx + 1;
+            if (left_idx >= len) break;
+            i32 left = cost[left_idx];
+            size_t right_idx = 2 * idx + 2;
+            if (right_idx >= len) {
+                if (left > item_cost) {
+                    cost[idx] = left;
+                    ind[idx] = ind[left_idx];
+                    idx = left_idx;
+                }
+                break;
+            }
+            i32 right = cost[right_idx];
+            if (left > item_cost) {
+                if (right > left) {
+                    cost[idx] = right;
+                    ind[idx] = ind[right_idx];
+                    idx = right_idx;
+                } else {
+                    cost[idx] = left;
+                    ind[idx] = ind[left_idx];
+                    idx = left_idx;
+                }
+            } else if (right > item_cost) {
+                cost[idx] = right;
+                ind[idx] = ind[right_idx];
+                idx = right_idx;
+            } else break;
+        }
+        cost[idx] = item_cost;
+        ind[idx] = item_ind;
+    }
+};
+
+
+//class MyQueue {
+//public:
+//#define QUEUE_MAX 3072
+//    alg::wdt::QItem<f32> data[QUEUE_MAX];
+//    size_t length{};
+//
+//    alg::wdt::QItem<f32> top() {
+//        return data[0];
+//    }
+//
+//    void push(alg::wdt::QItem<f32> item) {
+//        size_t idx{length++};
+//        while (idx) {
+//            size_t next{(idx - 1) / 2};
+//            alg::wdt::QItem<f32> parent = data[next];
+//            if (parent < item) {
+//                data[idx] = parent;
+//            } else break;
+//            idx = next;
+//        }
+//        data[idx] = item;
+//    }
+//
+//    [[nodiscard]] bool empty() const {
+//        return !length;
+//    }
+//
+//    void pop() {
+//        size_t idx{0};
+//        size_t len = --length;
+//        alg::wdt::QItem<f32> item = data[len];
+//        for (;;) {
+//            size_t left_idx = 2 * idx + 1;
+//            if (left_idx >= len) break;
+//            alg::wdt::QItem<f32> left = data[left_idx];
+//            size_t right_idx = 2 * idx + 2;
+//            if (right_idx >= len) {
+//                if (left > item) {
+//                    data[idx] = left;
+//                    idx = left_idx;
+//                }
+//                break;
+//            }
+//            alg::wdt::QItem<f32> right = data[right_idx];
+//            if (left > item) {
+//                if (right > left) {
+//                    data[idx] = right;
+//                    idx = right_idx;
+//                } else {
+//                    data[idx] = left;
+//                    idx = left_idx;
+//                }
+//            } else if (right > item) {
+//                data[idx] = right;
+//                idx = right_idx;
+//            } else break;
+//        }
+//        data[idx] = item;
+//    }
+//};
 
 class BlobDetector : public IBlobDetector {
 public:
@@ -57,7 +218,7 @@ private:
     Image<f32> m_img_flt;
     Image<f64> m_img_gftmp;
 
-    std::priority_queue<alg::wdt::QItem<f32>> m_wdt_queue;
+    MyQueue m_wdt_queue;
     std::vector<alg::gfit::Parameters<f64>> m_gf_params;
 
     std::vector<index_t> m_maximas;

--- a/src/contacts/advanced/detector.hpp
+++ b/src/contacts/advanced/detector.hpp
@@ -2,7 +2,6 @@
 
 #include <common/types.hpp>
 
-#include "algorithm/distance_transform.hpp"
 #include "algorithm/gaussian_fitting.hpp"
 
 #include <container/image.hpp>
@@ -17,10 +16,21 @@
 #include <bit>
 #include <vector>
 #include <queue>
+#include "arrayvec.hpp"
 
 using namespace iptsd::container;
 using namespace iptsd::math;
 
+namespace iptsd::contacts::advanced::alg {
+namespace wdt {
+
+template<typename T>
+struct QItem {
+    index_t idx;
+    T cost;
+};
+}
+}
 
 namespace iptsd::contacts::advanced {
 
@@ -199,7 +209,7 @@ public:
     auto data() -> Image<f32> & override;
     auto search() -> std::vector<Blob> const& override;
 
-private:
+public:
     auto process(Image<f32> const& hm) -> std::vector<Blob> const&;
 
     BlobDetectorConfig config;
@@ -219,16 +229,11 @@ private:
     Image<f64> m_img_gftmp;
 
     MyQueue m_wdt_queue;
-    std::vector<alg::gfit::Parameters<f64>> m_gf_params;
+    ArrayVec<alg::gfit::Parameters<f64>, 32> m_gf_params;
 
-    std::vector<index_t> m_maximas;
-    std::vector<ComponentStats> m_cstats;
-    std::vector<f32> m_cscore;
-
-    // gauss kernels
-    Kernel<f32, 5, 5> m_kern_pp;
-    Kernel<f32, 5, 5> m_kern_st;
-    Kernel<f32, 5, 5> m_kern_hs;
+    ArrayVec<index_t, 32> m_maximas;
+    ArrayVec<ComponentStats, 32> m_cstats;
+    ArrayVec<f32, 32> m_cscore;
 
     // parameters
     index2_t m_gf_window;

--- a/src/contacts/basic/cluster.cpp
+++ b/src/contacts/basic/cluster.cpp
@@ -9,7 +9,7 @@
 
 namespace iptsd::contacts::basic {
 
-Cluster::Cluster(container::Image<f32> &heatmap, container::Image<bool> &visited, index2_t center)
+Cluster::Cluster(container::Image<f32> &heatmap, container::Image<char> &visited, index2_t center)
 {
 	this->check(heatmap, visited, center);
 }
@@ -38,7 +38,7 @@ math::Mat2s<f64> Cluster::cov()
 	return math::Mat2s<f64> {r1, r3, r2};
 }
 
-void Cluster::check(container::Image<f32> &heatmap, container::Image<bool> &visited, index2_t pos)
+void Cluster::check(container::Image<f32> &heatmap, container::Image<char> &visited, index2_t pos)
 {
 	index2_t size = heatmap.size();
 

--- a/src/contacts/basic/cluster.hpp
+++ b/src/contacts/basic/cluster.hpp
@@ -20,14 +20,14 @@ public:
 	f64 w = 0;
 
 public:
-	Cluster(container::Image<f32> &heatmap, container::Image<bool> &visited, index2_t center);
+	Cluster(container::Image<f32> &heatmap, container::Image<char> &visited, index2_t center);
 
 	math::Vec2<f64> mean();
 	math::Mat2s<f64> cov();
 
 private:
 	void add(index2_t pos, f64 val);
-	void check(container::Image<f32> &heatmap, container::Image<bool> &visited, index2_t pos);
+	void check(container::Image<f32> &heatmap, container::Image<char> &visited, index2_t pos);
 };
 
 } /* namespace iptsd::contacts::basic */

--- a/src/contacts/basic/detector.hpp
+++ b/src/contacts/basic/detector.hpp
@@ -15,7 +15,7 @@ private:
 	BlobDetectorConfig config;
 
 	container::Image<f32> heatmap;
-	container::Image<bool> visited;
+	container::Image<char> visited;
 
 	std::vector<Blob> blobs {};
 

--- a/src/container/image.hpp
+++ b/src/container/image.hpp
@@ -14,7 +14,8 @@ namespace iptsd::container {
 
 template <class T> class Image {
 public:
-	using array_type = std::vector<T>;
+	static constexpr index_t max_array_size = 4096;
+	using array_type = std::array<T, max_array_size>;
 	using iterator = typename array_type::iterator;
 	using const_iterator = typename array_type::const_iterator;
 	using reverse_iterator = typename array_type::reverse_iterator;
@@ -63,8 +64,10 @@ template <class T> Image<T>::Image() : m_size {0, 0}
 {
 }
 
-template <class T> Image<T>::Image(index2_t size) : m_size {size}, m_data(size.span())
+template <class T> Image<T>::Image(index2_t size) : m_size {size}
 {
+	if (size.span() > max_array_size)
+		throw std::runtime_error("image size overflow");
 }
 
 template <class T> inline auto Image<T>::size() const -> index2_t
@@ -89,22 +92,22 @@ template <class T> inline auto Image<T>::data() const -> const_pointer
 
 template <class T> inline auto Image<T>::operator[](index2_t const &i) const -> const_reference
 {
-	return m_data[ravel(m_size, i)];
+	return data()[ravel(m_size, i)];
 }
 
 template <class T> inline auto Image<T>::operator[](index2_t const &i) -> reference
 {
-	return m_data[ravel(m_size, i)];
+	return data()[ravel(m_size, i)];
 }
 
 template <class T> inline auto Image<T>::operator[](index_t const &i) const -> const_reference
 {
-	return m_data[i];
+	return data()[i];
 }
 
 template <class T> inline auto Image<T>::operator[](index_t const &i) -> reference
 {
-	return m_data[i];
+	return data()[i];
 }
 
 template <class T> inline auto Image<T>::begin() -> iterator
@@ -114,7 +117,7 @@ template <class T> inline auto Image<T>::begin() -> iterator
 
 template <class T> inline auto Image<T>::end() -> iterator
 {
-	return m_data.end();
+	return begin() + m_size.span();
 }
 
 template <class T> inline auto Image<T>::begin() const -> const_iterator
@@ -134,7 +137,7 @@ template <class T> inline auto Image<T>::cbegin() const -> const_iterator
 
 template <class T> inline auto Image<T>::cend() const -> const_iterator
 {
-	return m_data.cend();
+	return cbegin() + m_size.span();
 }
 
 template <class T> inline constexpr auto Image<T>::ravel(index2_t size, index2_t i) -> index_t

--- a/src/container/image.hpp
+++ b/src/container/image.hpp
@@ -68,6 +68,8 @@ template <class T> Image<T>::Image(index2_t size) : m_size {size}
 {
 	if (size.span() > max_array_size)
 		throw std::runtime_error("image size overflow");
+	if (size.x != 64)
+		throw std::runtime_error("image is currently specialized");
 }
 
 template <class T> inline auto Image<T>::size() const -> index2_t
@@ -77,7 +79,7 @@ template <class T> inline auto Image<T>::size() const -> index2_t
 
 template <class T> inline auto Image<T>::stride() const -> index_t
 {
-	return m_size.x;
+	return 64;
 }
 
 template <class T> inline auto Image<T>::data() -> pointer
@@ -142,12 +144,12 @@ template <class T> inline auto Image<T>::cend() const -> const_iterator
 
 template <class T> inline constexpr auto Image<T>::ravel(index2_t size, index2_t i) -> index_t
 {
-	return i.y * size.x + i.x;
+	return i.y * 64 + i.x;
 }
 
 template <class T> inline constexpr auto Image<T>::unravel(index2_t size, index_t i) -> index2_t
 {
-	return {i % size.x, i / size.x};
+	return {i % 64, i / 64};
 }
 
 } /* namespace iptsd::container */

--- a/src/container/image.hpp
+++ b/src/container/image.hpp
@@ -14,7 +14,7 @@ namespace iptsd::container {
 
 template <class T> class Image {
 public:
-	static constexpr index_t max_array_size = 4096;
+	static constexpr index_t max_array_size = 2816;
 	using array_type = std::array<T, max_array_size>;
 	using iterator = typename array_type::iterator;
 	using const_iterator = typename array_type::const_iterator;

--- a/src/container/kernel.hpp
+++ b/src/container/kernel.hpp
@@ -40,17 +40,17 @@ public:
 	auto data() -> pointer;
 	[[nodiscard]] auto data() const -> const_pointer;
 
-	auto operator[](index2_t const &i) const -> const_reference;
-	auto operator[](index2_t const &i) -> reference;
+	constexpr auto operator[](index2_t const &i) const -> const_reference;
+	constexpr auto operator[](index2_t const &i) -> reference;
 
 	auto operator[](index_t const &i) const -> const_reference;
 	auto operator[](index_t const &i) -> reference;
 
-	auto begin() -> iterator;
-	auto end() -> iterator;
+	constexpr auto begin() -> iterator;
+	constexpr auto end() -> iterator;
 
-	[[nodiscard]] auto begin() const -> const_iterator;
-	[[nodiscard]] auto end() const -> const_iterator;
+	[[nodiscard]] constexpr auto begin() const -> const_iterator;
+	[[nodiscard]] constexpr auto end() const -> const_iterator;
 
 	[[nodiscard]] auto cbegin() const -> const_iterator;
 	[[nodiscard]] auto cend() const -> const_iterator;
@@ -100,13 +100,13 @@ template <class T, index_t Nx, index_t Ny> auto Kernel<T, Nx, Ny>::data() const 
 }
 
 template <class T, index_t Nx, index_t Ny>
-auto Kernel<T, Nx, Ny>::operator[](index2_t const &i) const -> const_reference
+constexpr auto Kernel<T, Nx, Ny>::operator[](index2_t const &i) const -> const_reference
 {
 	return this->buf[ravel({Nx, Ny}, i)];
 }
 
 template <class T, index_t Nx, index_t Ny>
-auto Kernel<T, Nx, Ny>::operator[](index2_t const &i) -> reference
+constexpr auto Kernel<T, Nx, Ny>::operator[](index2_t const &i) -> reference
 {
 	return this->buf[ravel({Nx, Ny}, i)];
 }
@@ -123,22 +123,22 @@ auto Kernel<T, Nx, Ny>::operator[](index_t const &i) -> reference
 	return this->buf[i];
 }
 
-template <class T, index_t Nx, index_t Ny> auto Kernel<T, Nx, Ny>::begin() -> iterator
+template <class T, index_t Nx, index_t Ny> constexpr auto Kernel<T, Nx, Ny>::begin() -> iterator
 {
 	return this->buf.begin();
 }
 
-template <class T, index_t Nx, index_t Ny> auto Kernel<T, Nx, Ny>::end() -> iterator
+template <class T, index_t Nx, index_t Ny> constexpr auto Kernel<T, Nx, Ny>::end() -> iterator
 {
 	return this->buf.end();
 }
 
-template <class T, index_t Nx, index_t Ny> auto Kernel<T, Nx, Ny>::begin() const -> const_iterator
+template <class T, index_t Nx, index_t Ny> constexpr auto Kernel<T, Nx, Ny>::begin() const -> const_iterator
 {
 	return this->buf.begin();
 }
 
-template <class T, index_t Nx, index_t Ny> auto Kernel<T, Nx, Ny>::end() const -> const_iterator
+template <class T, index_t Nx, index_t Ny> constexpr auto Kernel<T, Nx, Ny>::end() const -> const_iterator
 {
 	return this->buf.end();
 }

--- a/src/container/ops.hpp
+++ b/src/container/ops.hpp
@@ -32,14 +32,14 @@ inline auto minmax(C const &container) -> std::pair<typename C::value_type, type
 	return {*min, *max};
 }
 
-template <class S, class T, class F> inline void transform(S const &source, T &target, F fn)
+template <class S, class T, class F> constexpr inline void transform(S const &source, T &target, F fn)
 {
 	assert(source.size() == target.size());
 
 	std::transform(source.begin(), source.end(), target.begin(), fn);
 }
 
-template <class C, class F> inline void transform(C &container, F fn)
+template <class C, class F> constexpr inline void transform(C &container, F fn)
 {
 	std::transform(container.begin(), container.end(), container.begin(), fn);
 }

--- a/src/debug/dump.cpp
+++ b/src/debug/dump.cpp
@@ -196,7 +196,7 @@ static int main(gsl::span<char *> args)
 			const gsl::span<const u8> buf(buffer.data(), size);
 
 			spdlog::info("== Size: {} ==", size);
-			spdlog::info("{:ox}", buf);
+//			spdlog::info("{:ox}", buf);
 		} catch (std::exception &e) {
 			spdlog::warn(e.what());
 			errors++;


### PR DESCRIPTION
This is surprising. I thought I could only gain 5%. Nobody, not even me thought this would happen. Instead we gain another 1000us giving an 50% improvement.

***This PR isn't planned to be merged any time soon***, unless someone really insists. The fact that I didn't bother cleaning up the code proves this. The purpose of this PR is just to show that it's possible to get this size of improvements without changing the algorithm.

Looking at the perf graph, `MyQueue::{push,pop}` is 20%, so this seems to be the end of the road for this type of optimization. I had been doing architecture-preserving, function-only optimizations that didn't touch globally-passed-around data structures much. As I mentioned in the other PR, we might need to consider fixed-length data structures that trade flexibility for performance.

CPU dropped from 45% to 36% in iptsd, but still spikes to 100% when using 10 fingers. The next step I'm thinking of is trying to remove recursion/branching but that might greatly change the essence of the algorithms.

# Before

See #113

```
[22:20:12.187] [info] Vendor:       045E
[22:20:12.187] [info] Product:      099F
[22:20:12.187] [info] Buffer Size:  7487
[22:20:12.187] [info] Metadata:
[22:20:12.187] [info] rows=44, columns=64
[22:20:12.187] [info] width=25978, height=17319
[22:20:12.187] [info] transform=[-412.3492,0,25978,0,-402.76746,17319]
[22:20:12.187] [info] unknown=1, [178,182,180,1,178,182,180,1,90,171,100,20,172,177,175,2]
[22:20:16.228] [info] Ran 2010 times
[22:20:16.228] [info] Total: 4031356μs
[22:20:16.228] [info] Mean: 2005.65μs
[22:20:16.228] [info] Standard Deviation: 674.57μs
[22:20:16.228] [info] Minimum: 144.730μs
[22:20:16.228] [info] Maximum: 3357.086μs
```

# After

```
[14:39:40.948] [info] Vendor:       045E
[14:39:40.948] [info] Product:      099F
[14:39:40.948] [info] Buffer Size:  7487
[14:39:40.948] [info] Metadata:
[14:39:40.948] [info] rows=44, columns=64
[14:39:40.948] [info] width=25978, height=17319
[14:39:40.948] [info] transform=[-412.3492,0,25978,0,-402.76746,17319]
[14:39:40.948] [info] unknown=1, [178,182,180,1,178,182,180,1,90,171,100,20,172,177,175,2]
[14:39:42.951] [info] Ran 2010 times
[14:39:42.951] [info] Total: 1992742μs
[14:39:42.951] [info] Mean: 991.41μs
[14:39:42.951] [info] Standard Deviation: 324.57μs
[14:39:42.951] [info] Minimum: 86.030μs
[14:39:42.951] [info] Maximum: 1635.113μs
```

![image](https://user-images.githubusercontent.com/25646384/221275890-54d73271-2db8-46fe-a391-90d19d6ed660.png)
