### PR TITLE
fix: avoid unexpected failure in `override_dh_auto_install`

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -19,7 +19,7 @@ override_dh_strip:
 	dh_strip --no-automatic-dbgsym
 
 override_dh_auto_install:
-	DESTDIR=$(PWD)/debian/iptsd meson install -C $(shell dirname `find ./obj-* -name 'build.ninja'`) --skip-subprojects
+	DESTDIR=$(PWD)/debian/iptsd meson install -C $(shell dirname `find ./obj-* -maxdepth 1 -name 'build.ninja' -print -quit`) --skip-subprojects
 
 override_dh_dwz:
 	true


### PR DESCRIPTION
`find ...` should always return at most one result located at the top-level of current folder.

The current behavior may encounter with multiple returns, and cause wrong usage of `meson install -C <WD>`.