### PR TITLE
contacts: detection: Take advantage of initializer lists if using Eigen 3.4

### DIFF
--- a/src/contacts/detection/algorithms/gaussian.hpp
+++ b/src/contacts/detection/algorithms/gaussian.hpp
@@ -146,7 +146,14 @@ void assemble_system(Matrix6<T> &m,
 template <class T>
 bool extract_params(const Vector6<T> &chi, T &scale, Vector2<T> &mean, Matrix2<T> &prec)
 {
+#if EIGEN_VERSION_AT_LEAST(3,4,0)
+	prec.noalias() = -2 * Matrix2<T> {
+				      {chi[0], chi[1]},
+				      {chi[1], chi[2]},
+			      };
+#else
 	prec.noalias() = (Matrix2<T> {} << chi[0], chi[1], chi[1], chi[0]).finished() * -2;
+#endif
 
 	// mu = sigma * b = prec^-1 * B
 	const T d = prec.determinant();

--- a/src/contacts/detection/detector.hpp
+++ b/src/contacts/detection/detector.hpp
@@ -150,7 +150,12 @@ public:
 		// Prepare clusters for gaussian fitting
 		for (const Box &cluster : m_clusters) {
 			const Vector2<TFit> mean = cluster.cast<TFit>().center();
+#if EIGEN_VERSION_AT_LEAST(3,4,0)
+			const Matrix2<TFit> prec {{One<TFit>(), Zero<TFit>()},
+						  {Zero<TFit>(), One<TFit>()}};
+#else
 			const Matrix2<TFit> prec = Matrix2<TFit>::Identity();
+#endif
 
 			// min() and max() are inclusive so we need to add one
 			const Vector2<Eigen::Index> size = cluster.sizes() + one;


### PR DESCRIPTION
Eigen has `EIGEN_VERSION_AT_LEAST` marco on Macros.h, with that we can keep the initializer lists code instead of removing it.