### PR TITLE
apps: visualization: Handle window events properly

### DIFF
--- a/src/apps/visualization/visualize-sdl.hpp
+++ b/src/apps/visualization/visualize-sdl.hpp
@@ -68,6 +68,10 @@ public:
 	{
 		Visualize::on_data(data);
 
+		// Handle window events, such as the X11_NET_WM_PING
+		// event that is used to detect stuck programs.
+		SDL_PumpEvents();
+
 		constexpr usize FPS = 60;
 
 		// Limit how many times per seconds the screen is redrawn.


### PR DESCRIPTION
Quick drive by PR to prevent the windows from being marked as unresponsive. This adds an event handler in the on data callback. I also tried setting the hints from [here](https://wiki.libsdl.org/SDL2/SDL_HINT_VIDEO_X11_NET_WM_PING), but I'm on Wayland and those hints don't work. This works reliably.

So without this, I get this window after 5 seconds (Gnome 45, Wayload, NixOS 23.11).

![Screenshot from 2023-12-23 15-24-55](https://github.com/linux-surface/iptsd/assets/1732289/9b303ea2-4072-4a9b-9ee9-e404b9e6e5e2)
