### PR TITLE
Fix SP7 invalid data workaround

### DIFF
--- a/src/ipts/parser.hpp
+++ b/src/ipts/parser.hpp
@@ -118,8 +118,10 @@ private:
 			 * This causes a parse error, because the "0b" should be "0f".
 			 * So let's just ignore these packets.
 			 */
-			if (reader.size() == 4)
+			if (reader.size() == 4) {
+				reader.skip(reader.size());
 				return;
+			}
 
 			this->parse_report_frames(sub);
 			break;


### PR DESCRIPTION
Should fix #179.

Bug was introduced by 7b06d76. By moving the loop outside the function, the return no longer exits the loop.

Untested, unfortunately I don't have an SP7 to test on at the moment.