### PR TITLE
PKGBUILD: add /etc/iptsd.conf to backup

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -22,6 +22,10 @@ makedepends=(
 	'udev'
 )
 
+backup=(
+	'etc/iptsd.conf'
+)
+
 build() {
 	cd $startdir
 


### PR DESCRIPTION
This stops pacman from deleting users' configs that have changes in them whenever the package is updated.