### PR TITLE
update iptsd subproject wraps

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -91,7 +91,6 @@ spdlog = dependency(
 	fallback: ['spdlog', 'spdlog_dep'],
 	default_options: dependency_options + [
 		'tests=disabled',
-		'external_fmt=enabled',
 		'std_format=disabled',
 	],
 )

--- a/subprojects/cli11.wrap
+++ b/subprojects/cli11.wrap
@@ -1,9 +1,10 @@
 [wrap-file]
-directory = CLI11-2.3.2
-source_url = https://github.com/CLIUtils/CLI11/archive/refs/tags/v2.3.2.tar.gz
-source_filename = CLI11-2.3.2.tar.gz
-source_hash = aac0ab42108131ac5d3344a9db0fdf25c4db652296641955720a4fbe52334e22
-wrapdb_version = 2.3.2-1
+directory = CLI11-2.6.1
+source_url = https://github.com/CLIUtils/CLI11/archive/refs/tags/v2.6.1.tar.gz
+source_filename = CLI11-2.6.1.tar.gz
+source_hash = 377691f3fac2b340f12a2f79f523c780564578ba3d6eaf5238e9f35895d5ba95
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/cli11_2.6.1-1/CLI11-2.6.1.tar.gz
+wrapdb_version = 2.6.1-1
 
 [provide]
-cli11 = CLI11_dep
+dependency_names = CLI11

--- a/subprojects/eigen.wrap
+++ b/subprojects/eigen.wrap
@@ -1,13 +1,13 @@
 [wrap-file]
-directory = eigen-3.4.0
-source_url = https://gitlab.com/libeigen/eigen/-/archive/3.4.0/eigen-3.4.0.tar.bz2
-source_filename = eigen-3.4.0.tar.bz2
-source_hash = b4c198460eba6f28d34894e3a5710998818515104d6e74e5cc331ce31e46e626
-patch_filename = eigen_3.4.0-2_patch.zip
-patch_url = https://wrapdb.mesonbuild.com/v2/eigen_3.4.0-2/get_patch
-patch_hash = cb764fd9fec02d94aaa2ec673d473793c0d05da4f4154c142f76ef923ea68178
-source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/eigen_3.4.0-2/eigen-3.4.0.tar.bz2
-wrapdb_version = 3.4.0-2
+directory = eigen-5.0.1
+source_url = https://gitlab.com/libeigen/eigen/-/archive/5.0.1/eigen-5.0.1.tar.bz2
+source_filename = eigen-5.0.1.tar.bz2
+source_hash = e4de6b08f33fd8b8985d2f204381408c660bffa6170ac65b68ae1bd3cd575c0a
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/eigen_5.0.1-1/eigen-5.0.1.tar.bz2
+patch_filename = eigen_5.0.1-1_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/eigen_5.0.1-1/get_patch
+patch_hash = 23407632af9388f4585547028c4ed363ff54875872cbf3e89c2085a14397f555
+wrapdb_version = 5.0.1-1
 
 [provide]
-eigen3 = eigen_dep
+dependency_names = eigen3

--- a/subprojects/fmt.wrap
+++ b/subprojects/fmt.wrap
@@ -1,13 +1,13 @@
 [wrap-file]
-directory = fmt-10.2.0
-source_url = https://github.com/fmtlib/fmt/archive/10.2.0.tar.gz
-source_filename = fmt-10.2.0.tar.gz
-source_hash = 3ca91733a7313a8ad41c0885929415f8ec0a2a31d4dc7e27e9331412f4ca26ac
-patch_filename = fmt_10.2.0-1_patch.zip
-patch_url = https://wrapdb.mesonbuild.com/v2/fmt_10.2.0-1/get_patch
-patch_hash = aa93abb8f20cb8f739d794846c69264d57fa339e8ee78a78894f8ef2348c8080
-source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/fmt_10.2.0-1/fmt-10.2.0.tar.gz
-wrapdb_version = 10.2.0-1
+directory = fmt-12.0.0
+source_url = https://github.com/fmtlib/fmt/archive/12.0.0.tar.gz
+source_filename = fmt-12.0.0.tar.gz
+source_hash = aa3e8fbb6a0066c03454434add1f1fc23299e85758ceec0d7d2d974431481e40
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/fmt_12.0.0-1/fmt-12.0.0.tar.gz
+patch_filename = fmt_12.0.0-1_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/fmt_12.0.0-1/get_patch
+patch_hash = 307f288ebf3850abf2f0c50ac1fb07de97df9538d39146d802f3c0d6cada8998
+wrapdb_version = 12.0.0-1
 
 [provide]
-fmt = fmt_dep
+dependency_names = fmt

--- a/subprojects/inih.wrap
+++ b/subprojects/inih.wrap
@@ -1,10 +1,10 @@
 [wrap-file]
-directory = inih-r57
-source_url = https://github.com/benhoyt/inih/archive/r57.tar.gz
-source_filename = inih-r57.tar.gz
-source_hash = f03f98ca35c3adb56b2358573c8d3eda319ccd5287243d691e724b7eafa970b3
-source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/inih_r57-1/inih-r57.tar.gz
-wrapdb_version = r57-1
+directory = inih-r62
+source_url = https://github.com/benhoyt/inih/archive/r62.tar.gz
+source_filename = inih-r62.tar.gz
+source_hash = 9c15fa751bb8093d042dae1b9f125eb45198c32c6704cd5481ccde460d4f8151
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/inih_r62-1/inih-r62.tar.gz
+wrapdb_version = r62-1
 
 [provide]
 inih = inih_dep

--- a/subprojects/microsoft-gsl.wrap
+++ b/subprojects/microsoft-gsl.wrap
@@ -1,13 +1,13 @@
 [wrap-file]
-directory = GSL-4.0.0
-source_url = https://github.com/microsoft/GSL/archive/v4.0.0.zip
-source_filename = GSL-4.0.0.zip
-source_hash = eb91fcb10a6aa5ccb1d224e07a56c8ecffe9a1bb601fa1848276ec46a2200bfb
-patch_filename = microsoft-gsl_4.0.0-1_patch.zip
-patch_url = https://wrapdb.mesonbuild.com/v2/microsoft-gsl_4.0.0-1/get_patch
-patch_hash = 6134805c5879dbf63497c44dc14bbc8280880b99705f7ad9ddd33f01253305ed
-wrapdb_version = 4.0.0-1
+directory = GSL-4.2.0
+source_url = https://github.com/microsoft/GSL/archive/v4.2.0.zip
+source_filename = GSL-4.2.0.zip
+source_hash = f694e7b0f3debc0c55fe138efb5dd9f5c402989c0dc04e8a74afc9c155cb66b9
+patch_filename = microsoft-gsl_4.2.0-1_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/microsoft-gsl_4.2.0-1/get_patch
+patch_hash = d08afc6735731bb3dd10d84395423feebb6865ef6c9e78e522c8764fb9f0d9d1
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/microsoft-gsl_4.2.0-1/GSL-4.2.0.zip
+wrapdb_version = 4.2.0-1
 
 [provide]
 microsoft_gsl = microsoft_gsl_dep
-

--- a/subprojects/sdl2.wrap
+++ b/subprojects/sdl2.wrap
@@ -1,13 +1,13 @@
 [wrap-file]
-directory = SDL2-2.28.5
-source_url = https://github.com/libsdl-org/SDL/releases/download/release-2.28.5/SDL2-2.28.5.tar.gz
-source_filename = SDL2-2.28.5.tar.gz
-source_hash = 332cb37d0be20cb9541739c61f79bae5a477427d79ae85e352089afdaf6666e4
-patch_filename = sdl2_2.28.5-2_patch.zip
-patch_url = https://wrapdb.mesonbuild.com/v2/sdl2_2.28.5-2/get_patch
-patch_hash = 8a5d7e7cd58932e0231963d42aa79776c2af1aceea6506a06be25a56935121eb
-source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/sdl2_2.28.5-2/SDL2-2.28.5.tar.gz
-wrapdb_version = 2.28.5-2
+directory = SDL2-2.32.8
+source_url = https://github.com/libsdl-org/SDL/releases/download/release-2.32.8/SDL2-2.32.8.tar.gz
+source_filename = SDL2-2.32.8.tar.gz
+source_hash = 0ca83e9c9b31e18288c7ec811108e58bac1f1bb5ec6577ad386830eac51c787e
+patch_filename = sdl2_2.32.8-1_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/sdl2_2.32.8-1/get_patch
+patch_hash = 5df17ea39ca418826db20e96bd821fa52b5718dac64b6225119fb6588c2744f0
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/sdl2_2.32.8-1/SDL2-2.32.8.tar.gz
+wrapdb_version = 2.32.8-1
 
 [provide]
 sdl2 = sdl2_dep

--- a/subprojects/spdlog.wrap
+++ b/subprojects/spdlog.wrap
@@ -1,13 +1,13 @@
 [wrap-file]
-directory = spdlog-1.13.0
-source_url = https://github.com/gabime/spdlog/archive/refs/tags/v1.13.0.tar.gz
-source_filename = spdlog-1.13.0.tar.gz
-source_hash = 534f2ee1a4dcbeb22249856edfb2be76a1cf4f708a20b0ac2ed090ee24cfdbc9
-patch_filename = spdlog_1.13.0-1_patch.zip
-patch_url = https://wrapdb.mesonbuild.com/v2/spdlog_1.13.0-1/get_patch
-patch_hash = 556b539cf582a46673ede4202ac037b891328dd5ea76862ffe05b060fc4f4775
-source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/spdlog_1.13.0-1/spdlog-1.13.0.tar.gz
-wrapdb_version = 1.13.0-1
+directory = spdlog-1.15.3
+source_url = https://github.com/gabime/spdlog/archive/refs/tags/v1.15.3.tar.gz
+source_filename = spdlog-1.15.3.tar.gz
+source_hash = 15a04e69c222eb6c01094b5c7ff8a249b36bb22788d72519646fb85feb267e67
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/spdlog_1.15.3-5/spdlog-1.15.3.tar.gz
+patch_filename = spdlog_1.15.3-5_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/spdlog_1.15.3-5/get_patch
+patch_hash = 5e0eaf0002ff589cd8dac58e1b38c297422e7a0404d7d47ff0d2e285ed18169c
+wrapdb_version = 1.15.3-5
 
 [provide]
-spdlog = spdlog_dep
+dependency_names = spdlog


### PR DESCRIPTION
This pull request updates several third-party dependencies to newer versions and makes a minor adjustment to the `spdlog` dependency options. The main focus is on keeping the project up-to-date with the latest features, bug fixes, and compatibility improvements from upstream libraries.

Dependency version upgrades:

* Upgraded `CLI11` from version 2.3.2 to 2.6.1, updating the directory, source URL, hash, and Meson wrap metadata.
* Upgraded `Eigen` from version 3.4.0 to 5.0.1, including new patch information and updated metadata.
* Upgraded `fmt` from version 10.2.0 to 12.0.0, updating all related wrap and patch details.
* Upgraded `inih` from version r57 to r62, updating source and metadata accordingly.
* Upgraded `microsoft-gsl` from version 4.0.0 to 4.2.0, with updated patch and fallback information.
* Upgraded `SDL2` from version 2.28.5 to 2.32.8, including new patch and source details.
* Upgraded `spdlog` from version 1.13.0 to 1.15.3, with updated patch, source, and metadata.

Build configuration adjustment:

* Removed the `external_fmt=enabled` option from the `spdlog` dependency configuration in `src/meson.build`, likely to align with changes in `spdlog` or the project's usage of the `fmt` library.