### PR TITLE
Fix typo in configuration loader breaking contact aspect logic

### DIFF
--- a/src/core/linux/config-loader.hpp
+++ b/src/core/linux/config-loader.hpp
@@ -173,7 +173,7 @@ private:
 		this->get(ini, "Contacts", "OrientationThresholdMax", m_config.contacts_orientation_thresh_max);
 		this->get(ini, "Contacts", "SizeMin", m_config.contacts_size_min);
 		this->get(ini, "Contacts", "SizeMax", m_config.contacts_size_max);
-		this->get(ini, "Contacts", "AspectMin", m_config.contacts_aspect_max);
+		this->get(ini, "Contacts", "AspectMin", m_config.contacts_aspect_min);
 		this->get(ini, "Contacts", "AspectMax", m_config.contacts_aspect_max);
 
 		this->get(ini, "Stylus", "Disable", m_config.stylus_disable);


### PR DESCRIPTION
There was a typo in the configuration loader causing the `AspectMin` configuration option to be set to the value of `AspectMax`. Fixed the typo and seems to be working as intended now.