### PR TITLE
iptsd@.service stops itself ~6s after start on cold boot due to StopWhenUnneeded=yes

### DIFF
--- a/etc/systemd/iptsd@.service.in
+++ b/etc/systemd/iptsd@.service.in
@@ -1,7 +1,6 @@
 [Unit]
 Description=Intel Precise Touch & Stylus Daemon
 Documentation=https://github.com/linux-surface/iptsd
-StopWhenUnneeded=yes
 BindsTo=%i.device
 
 [Service]


### PR DESCRIPTION
## Problem
`iptsd@.service` sets `StopWhenUnneeded=yes`, but the unit is only ever
activated via udev's `SYSTEMD_WANTS` on the hidraw device unit - a
one-time job trigger, not a persistent `Wants=`. As a result, systemd
decides nothing "needs" the unit a few seconds after start and stops
it, even though the hidraw device is still present.

On cold boot this means: iptsd starts, connects to the IPTS device,
and is stopped by systemd itself ~6s later. Touch/pen then stop
working until the hidraw device is recreated (e.g. by suspend/resume,
which re-triggers the udev rule).

## Evidence
- `StopWhenUnneeded=yes` was added in bcb12c690 together with
  `BindsTo=%I` (later fixed to `%i.device` for escaping in 72afde5f4),
  with the stated goal "make sure the service stops when the device is
  removed."
- Per `systemd.unit(5)`, `BindsTo=` already fully covers that case:
  "...it also does so when a listed unit stops unexpectedly...the
  backing device of a device unit might be unplugged."
- `StopWhenUnneeded=` is a different, unrelated mechanism: "a unit will
  be automatically cleaned up if no other active unit requires it" -
  which is exactly what breaks here, since nothing durably "requires"
  a udev-triggered instance.

## Reproduction (Surface Pro 4, Fedora 44)
```
$ journalctl -u 'iptsd@dev-hidraw3.service' -b
Aug 20 06:08:33 surface iptsd[1339]: [info] Connected to device 045E:0984
Aug 20 06:08:33 surface iptsd[1339]: [info] Running in Touchscreen mode
Aug 20 06:08:39 surface systemd[1]: Stopping iptsd@dev-hidraw3.service...
Aug 20 06:08:39 surface systemd[1]: iptsd@dev-hidraw3.service: Deactivated successfully.
```

Manual workaround that confirms/fixes it: `systemctl edit iptsd@.service`
with `StopWhenUnneeded=no` - service stays active across cold boot,
touch/pen work normally. This has also been confirmed working on the
reporter's Surface Pro 4.

## Fix
Remove `StopWhenUnneeded=` - `BindsTo=%i.device` already provides the
originally intended "stop on device removal" behavior.

Related KompassOS tracking issue: https://github.com/L0g0ff/KompassOS/issues/85