### PR TITLE
udev: hide raw ithc input nodes duplicated by iptsd

### DIFF
--- a/etc/udev/50-iptsd.rules.in
+++ b/etc/udev/50-iptsd.rules.in
@@ -2,3 +2,11 @@ SUBSYSTEM=="hidraw", ACTION=="add", TAG+="systemd", \
 	PROGRAM="@bindir@/iptsd-check-device --quiet $env{DEVNAME}", \
 	PROGRAM="/bin/systemd-escape --path $env{DEVNAME}", \
 	ENV{SYSTEMD_WANTS}+="iptsd@$result.service"
+
+# Hide the raw Intel Touch Host Controller (ithc) input nodes from libinput.
+# On Tiger Lake devices (e.g. Surface Pro 7+/8) these duplicate the calibrated
+# nodes iptsd publishes above ("IPTSD Virtual Touchscreen"/"IPTSD Virtual
+# Stylus") and report a 16:9 geometry on panels that are actually 3:2, causing
+# duplicate touch events and distorted coordinates near the edges.
+SUBSYSTEM=="input", ATTRS{name}=="Intel Touch Host Controller*", \
+	ENV{ID_INPUT}="", ENV{ID_INPUT_TOUCHSCREEN}="", ENV{ID_INPUT_TABLET}=""


### PR DESCRIPTION
On Tiger Lake devices (Surface Pro 7+/8), the ithc kernel driver exposes
raw "Intel Touch Host Controller" input nodes alongside the calibrated
virtual devices iptsd creates. The raw nodes report a 16:9 geometry that
does not match the 3:2 panel, and libinput picking both up causes
duplicate touch events and distorted coordinates near the edges.

This rule strips ID_INPUT/ID_INPUT_TOUCHSCREEN/ID_INPUT_TABLET from the
raw nodes so libinput only sees the calibrated IPTSD Virtual
Touchscreen/Stylus devices.

Verified on a Surface Pro 7+ running Fedora 44, kernel 6.19.8-surface:
before this rule, `udevadm info` shows both the raw and virtual
touchscreen nodes tagged ID_INPUT_TOUCHSCREEN=1; after it, only the
IPTSD Virtual Touchscreen node is.

Fixes #220